### PR TITLE
NeoGPS library example usage

### DIFF
--- a/AnalogGPSChrono.ino
+++ b/AnalogGPSChrono.ino
@@ -1,7 +1,7 @@
 #include "NMEAGPS.h"
 #include <SoftwareSerial.h>
 
-SoftwareSerial ss(50, 255);
+SoftwareSerial ss(0, 30);
 NMEAGPS gps;
 
 void setup()

--- a/AnalogGPSChrono.ino
+++ b/AnalogGPSChrono.ino
@@ -1,12 +1,8 @@
-#include <TinyGPS++.h>
+#include "NMEAGPS.h"
 #include <SoftwareSerial.h>
-#include <math.h>
 
-int pos = 0;
-float lastSpeed = 0;
-
-TinyGPSPlus gps;
-SoftwareSerial ss(0, 30);
+SoftwareSerial ss(50, 255);
+NMEAGPS gps;
 
 void setup()
 {
@@ -20,6 +16,10 @@ void setup()
 
 void loop()
 {
-  speedProcess(gps.speed.mph(), gps.speed.isValid());
-  smartDelay(10);
+  if (gps.available( ss )) {
+    const gps_fix & fix = gps.read();
+    if (fix.valid.speed)
+      speedProcess( fix.spd.whole ); // knots
+  }
 }
+

--- a/CosaCompat.h
+++ b/CosaCompat.h
@@ -1,0 +1,9 @@
+#ifndef COSACOMPAT_H
+#define COSACOMPAT_H
+
+#include <avr/pgmspace.h>
+
+typedef PGM_P str_P;
+#define __PROGMEM PROGMEM
+
+#endif

--- a/GPSfix.h
+++ b/GPSfix.h
@@ -1,0 +1,490 @@
+#ifndef GPSFIX_H
+#define GPSFIX_H
+
+/**
+ * @file GPSfix.h
+ * @version 3.0
+ *
+ * @section License
+ * Copyright (C) 2016, SlashDevin
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#include "NeoGPS_cfg.h"
+#include "GPSfix_cfg.h"
+
+#if defined( GPS_FIX_DATE ) | defined( GPS_FIX_TIME )
+  #include "Time.h"
+#endif
+
+#ifdef GPS_FIX_LOCATION_DMS
+  #include "DMS.h"
+#endif
+
+/**
+ * A structure for holding a GPS fix: time, position, velocity, etc.
+ *
+ * Because GPS devices report various subsets of a coherent fix, 
+ * this class tracks which members of the fix are being reported: 
+ * each part has its own validity flag. Also, operator |= implements 
+ * merging multiple reports into one consolidated report.
+ *
+ * @section Limitations
+ * Reports are not really fused with an algorithm; if present in 
+ * the source, they are simply replaced in the destination.
+ *
+ */
+
+class gps_fix
+{
+public:
+
+  // Default Constructor
+  gps_fix() { init(); };
+
+  //------------------------------------------------------------------
+  // 'whole_frac' is a utility structure that holds the two parts 
+  //    of a floating-point number.
+  //
+  // This is used for Altitude, Heading and Speed, which require more
+  //   significant digits than a 16-bit number.
+  //
+  // When parsing floating-point fields, the decimal point is used as
+  //   a separator for these two parts.  This is much more efficient
+  //   than calling 'long' or 'floating-point' math subroutines.
+  //
+  // This requires knowing the exponent on the fraction when a simple type
+  //   (e.g., float or int) is needed.  For example, 'altitude()' knows that
+  //   the whole part was stored as integer meters, and the fractional part
+  //   was stored as integer centimeters.
+  //
+  // Unless you want the speed and precision of the two integer parts, you 
+  //   shouldn't have to use 'whole_frac'.  Instead, use the
+  //   accessor functions for each of the specific fields for
+  //   Altitude, Heading and Speed.
+
+  struct whole_frac {
+    int16_t whole;
+    int16_t frac;
+    void init() { whole = 0; frac = 0; };
+    int32_t int32_00() const { return ((int32_t)whole) * 100L + frac; };
+    int16_t int16_00() const { return whole * 100 + frac; };
+    int32_t int32_000() const { return whole * 1000L + frac; };
+    float float_00() const { return ((float)whole) + ((float)frac)*0.01; };
+    float float_000() const { return ((float)whole) + ((float)frac)*0.001; };
+  } NEOGPS_PACKED;
+
+  //--------------------------------------------------------------
+  // Members of a GPS fix
+  //
+  // Each member is separately enabled or disabled by the CFG file
+  //   by #ifdef/#endif wrappers.
+  // Each member has a storage declaration that depends on the
+  //   precision and type of data available from GPS devices.
+  // Some members have a separate accessor function that converts the
+  //   internal storage type to a more common or convenient type
+  //   for use by an application.
+  // For example, latitude data is internally stored as a 32-bit integer,
+  //   where the reported degrees have been multiplied by 10^7.  Many
+  //   applications expect a floating-point value, so a floating-point
+  //   accessor is provided: 'latitude()'.  This function converts the
+  //   internal 32-bit integer to a floating-point value, and then
+  //   divides it by 10^7.  The returned value is now a floating-point
+  //   degrees value.
+
+  #ifdef GPS_FIX_LOCATION
+    int32_t       lat;  // degrees * 1e7, negative is South
+    int32_t       lon;  // degrees * 1e7, negative is West
+
+    int32_t latitudeL() const { return lat; };
+    float   latitude () const { return ((float) lat) * 1.0e-7; }; // accuracy loss
+
+    int32_t longitudeL() const { return lon; };
+    float   longitude () const { return ((float) lon) * 1.0e-7; }; // accuracy loss
+  #endif
+
+  #ifdef GPS_FIX_LOCATION_DMS
+    DMS_t latitudeDMS;
+    DMS_t longitudeDMS;    
+  #endif
+  
+  #ifdef GPS_FIX_ALTITUDE
+    whole_frac    alt; // .01 meters
+
+    int32_t altitude_cm() const { return alt.int32_00(); };
+    float   altitude   () const { return alt.float_00(); };
+  #endif
+
+  #ifdef GPS_FIX_SPEED
+    whole_frac    spd; // .001 nautical miles per hour
+
+    uint32_t speed_mkn () const { return spd.int32_000(); };
+    float    speed     () const { return spd.float_000(); };
+
+    // Utilities for speed in other units
+    CONST_CLASS_DATA float KM_PER_NMI = 1.852;
+    float    speed_kph () const { return speed() * KM_PER_NMI; };
+
+    CONST_CLASS_DATA uint16_t M_PER_NMI = 1852;
+    uint32_t speed_metersph() const { return (spd.whole * M_PER_NMI) + (spd.frac * M_PER_NMI)/1000; };
+
+    CONST_CLASS_DATA float MI_PER_NMI = 1.150779;
+    float  speed_mph() const { return speed() * MI_PER_NMI; };
+  #endif
+
+  #ifdef GPS_FIX_HEADING
+    whole_frac    hdg; //  .01 degrees
+
+    uint16_t heading_cd() const { return hdg.int16_00(); };
+    float    heading   () const { return hdg.float_00(); };
+  #endif
+
+  //--------------------------------------------------------
+  // Dilution of Precision is a measure of the current satellite
+  // constellation geometry WRT how 'good' it is for determining a 
+  // position.  This is _independent_ of signal strength and many 
+  // other factors that may be internal to the receiver.
+  // It _cannot_ be used to determine position accuracy in meters.
+  // Instead, use the LAT/LON/ALT error in cm members, which are 
+  //   populated by GST sentences.
+
+  #ifdef GPS_FIX_HDOP
+    uint16_t           hdop; // Horizontal Dilution of Precision x 1000
+  #endif
+  #ifdef GPS_FIX_VDOP
+    uint16_t           vdop; // Horizontal Dilution of Precision x 1000
+  #endif
+  #ifdef GPS_FIX_PDOP
+    uint16_t           pdop; // Horizontal Dilution of Precision x 1000
+  #endif
+
+  //--------------------------------------------------------
+  //  Error estimates for latitude, longitude and altitude, in centimeters.
+
+  #ifdef GPS_FIX_LAT_ERR
+    uint16_t lat_err_cm;
+    float lat_err() const { return lat_err_cm / 100.0; }
+  #endif
+
+  #ifdef GPS_FIX_LON_ERR
+    uint16_t lon_err_cm;
+    float lon_err() const { return lon_err_cm / 100.0; }
+  #endif
+
+  #ifdef GPS_FIX_ALT_ERR
+    uint16_t alt_err_cm;
+    float alt_err() const { return alt_err_cm / 100.0; }
+  #endif
+
+  //--------------------------------------------------------
+  // Height of the geoid above the WGS84 ellipsoid
+  #ifdef GPS_FIX_GEOID_HEIGHT
+    whole_frac    geoidHt; // .01 meters
+
+    int32_t geoidHeight_cm() const { return geoidHt.int32_00(); };
+    float   geoidHeight   () const { return geoidHt.float_00(); };
+  #endif
+
+  //--------------------------------------------------------
+  // Number of satellites used to calculate a fix.
+  #ifdef GPS_FIX_SATELLITES
+    uint8_t   satellites;
+  #endif
+
+  //--------------------------------------------------------
+  //  Date and Time for the fix
+  #if defined(GPS_FIX_DATE) | defined(GPS_FIX_TIME)
+    NeoGPS::time_t  dateTime   ; // Date and Time in one structure
+    uint8_t         dateTime_cs; // hundredths of a second
+  #endif
+
+  //--------------------------------------------------------
+  // The current fix status or mode of the GPS device.
+  //
+  // Unfortunately, the NMEA sentences are a little inconsistent 
+  //   in their use of "status" and "mode". Both fields are mapped 
+  //   onto this enumerated type.  Be aware that different 
+  //   manufacturers interpret them differently.  This can cause 
+  //   problems in sentences which include both types (e.g., GPGLL).
+  //
+  // Note: Sorted by increasing accuracy.  See also /operator |=/.
+   
+  enum status_t {
+    STATUS_NONE,
+    STATUS_EST,
+    STATUS_TIME_ONLY,
+    STATUS_STD,
+    STATUS_DGPS
+  };
+
+  status_t  status NEOGPS_BF(8);
+
+  //--------------------------------------------------------
+  //  Flags to indicate which members of this fix are valid.
+  //
+  //  Because different sentences contain different pieces of a fix,
+  //    each piece can be valid or NOT valid.  If the GPS device does not
+  //    have good reception, some fields may not contain any value.
+  //    Those empty fields will be marked as NOT valid.
+
+  struct valid_t {
+    bool status NEOGPS_BF(1);
+
+    #if defined(GPS_FIX_DATE)
+      bool date NEOGPS_BF(1);
+    #endif
+
+    #if defined(GPS_FIX_TIME)
+      bool time NEOGPS_BF(1);
+    #endif
+
+    #if defined( GPS_FIX_LOCATION ) | defined( GPS_FIX_LOCATION_DMS )
+      bool location NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_ALTITUDE
+      bool altitude NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_SPEED
+      bool speed NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_HEADING
+      bool heading NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_SATELLITES
+      bool satellites NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_HDOP
+      bool hdop NEOGPS_BF(1);
+    #endif
+    #ifdef GPS_FIX_VDOP
+      bool vdop NEOGPS_BF(1);
+    #endif
+    #ifdef GPS_FIX_PDOP
+      bool pdop NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_LAT_ERR
+      bool lat_err NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_LON_ERR
+      bool lon_err NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_ALT_ERR
+      bool alt_err NEOGPS_BF(1);
+    #endif
+
+    #ifdef GPS_FIX_GEOID_HEIGHT
+      bool geoidHeight NEOGPS_BF(1);
+    #endif
+
+    // Initialize all flags to false
+    void init()
+      {
+        uint8_t *all = (uint8_t *) this;
+        for (uint8_t i=0; i<sizeof(*this); i++)
+          *all++ = 0;
+      }
+
+    // Merge these valid flags with another set of valid flags
+    void operator |=( const valid_t & r )
+      {
+        uint8_t *all = (uint8_t *) this;
+        const uint8_t *r_all = (const uint8_t *) &r;
+        for (uint8_t i=0; i<sizeof(*this); i++)
+          *all++ |= *r_all++;
+      }
+  } NEOGPS_PACKED
+      valid;        // This is the name of the collection of valid flags
+
+  //--------------------------------------------------------
+  //  Initialize a fix.  All configured members are set to zero.
+
+  void init()
+  {
+    #ifdef GPS_FIX_LOCATION
+      lat = lon = 0;
+    #endif
+
+    #ifdef GPS_FIX_LOCATION_DMS
+      latitudeDMS.init();
+      longitudeDMS.init();
+    #endif
+
+    #ifdef GPS_FIX_ALTITUDE
+      alt.init();
+    #endif
+
+    #ifdef GPS_FIX_SPEED
+      spd.init();
+    #endif
+
+    #ifdef GPS_FIX_HEADING
+      hdg.init();
+    #endif
+
+    #ifdef GPS_FIX_HDOP
+      hdop = 0;
+    #endif
+    #ifdef GPS_FIX_VDOP
+      vdop = 0;
+    #endif
+    #ifdef GPS_FIX_PDOP
+      pdop = 0;
+    #endif
+
+    #ifdef GPS_FIX_LAT_ERR
+      lat_err_cm = 0;
+    #endif
+    #ifdef GPS_FIX_LON_ERR
+      lon_err_cm = 0;
+    #endif
+    #ifdef GPS_FIX_ALT_ERR
+      alt_err_cm = 0;
+    #endif
+
+    #ifdef GPS_FIX_GEOID_HEIGHT
+      geoidHt.init();
+    #endif
+
+    #ifdef GPS_FIX_SATELLITES
+      satellites = 0;
+    #endif
+
+    #if defined(GPS_FIX_DATE) | defined(GPS_FIX_TIME)
+      dateTime.init();
+    #endif
+    #if defined(GPS_FIX_TIME)
+      dateTime_cs = 0;
+    #endif
+
+    status = STATUS_NONE;
+
+    valid.init();
+  
+  } // init
+
+  //-------------------------------------------------------------
+  // Merge valid fields from the right fix into a "fused" fix 
+  //   on the left (i.e., /this/).
+  //
+  // Usage:  gps_fix left, right;
+  //         left |= right;  // explicit merge
+
+  gps_fix & operator |=( const gps_fix & r )
+  {
+    // Replace /status/  only if the right is more "accurate".
+    if (r.valid.status && (!valid.status || (status < r.status)))
+      status = r.status;
+
+    #ifdef GPS_FIX_DATE
+      if (r.valid.date) {
+        dateTime.date  = r.dateTime.date;
+        dateTime.month = r.dateTime.month;
+        dateTime.year  = r.dateTime.year;
+      }
+    #endif
+
+    #ifdef GPS_FIX_TIME
+      if (r.valid.time) {
+        dateTime.hours   = r.dateTime.hours;
+        dateTime.minutes = r.dateTime.minutes;
+        dateTime.seconds = r.dateTime.seconds;
+        dateTime_cs      = r.dateTime_cs;
+      }
+    #endif
+
+    #ifdef GPS_FIX_LOCATION
+      if (r.valid.location) {
+        lat = r.lat;
+        lon = r.lon;
+      }
+    #endif
+
+    #ifdef GPS_FIX_LOCATION_DMS
+      if (r.valid.location) {
+        latitudeDMS  = r.latitudeDMS;
+        longitudeDMS = r.longitudeDMS;
+      }
+    #endif
+
+    #ifdef GPS_FIX_ALTITUDE
+      if (r.valid.altitude)
+        alt = r.alt;
+    #endif
+
+    #ifdef GPS_FIX_HEADING
+      if (r.valid.heading)
+        hdg = r.hdg;
+    #endif
+
+    #ifdef GPS_FIX_SPEED
+      if (r.valid.speed)
+        spd = r.spd;
+    #endif
+
+    #ifdef GPS_FIX_SATELLITES
+      if (r.valid.satellites)
+        satellites = r.satellites;
+    #endif
+
+    #ifdef GPS_FIX_HDOP
+      if (r.valid.hdop)
+        hdop = r.hdop;
+    #endif
+
+    #ifdef GPS_FIX_VDOP
+      if (r.valid.vdop)
+        vdop = r.vdop;
+    #endif
+
+    #ifdef GPS_FIX_PDOP
+      if (r.valid.pdop)
+        pdop = r.pdop;
+    #endif
+
+    #ifdef GPS_FIX_LAT_ERR
+      if (r.valid.lat_err)
+        lat_err_cm = r.lat_err_cm;
+    #endif
+
+    #ifdef GPS_FIX_LON_ERR
+      if (r.valid.lon_err)
+        lon_err_cm = r.lon_err_cm;
+    #endif
+
+    #ifdef GPS_FIX_ALT_ERR
+      if (r.valid.alt_err)
+        alt_err_cm = r.alt_err_cm;
+    #endif
+
+    #ifdef GPS_FIX_GEOID_HEIGHT
+      if (r.valid.geoidHeight)
+        geoidHt = r.geoidHt;
+    #endif
+
+    // Update all the valid flags
+    valid |= r.valid;
+
+    return *this;
+
+  } // operator |=
+
+} NEOGPS_PACKED;
+
+#endif

--- a/GPSfix_cfg.h
+++ b/GPSfix_cfg.h
@@ -1,0 +1,35 @@
+#ifndef GPS_FIX_CFG
+#define GPS_FIX_CFG
+
+/**
+ * Enable/disable the storage for the members of a fix.
+ *
+ * Disabling a member prevents it from being parsed from a received message.
+ * The disabled member cannot be accessed or stored, and its validity flag 
+ * would not be available.  It will not be declared, and code that uses that
+ * member will not compile.
+ *
+ * DATE and TIME are somewhat coupled in that they share a single `time_t`,
+ * but they have separate validity flags.
+ *
+ * See also note regarding the DOP members, below.
+ *
+ */
+
+//#define GPS_FIX_DATE
+//#define GPS_FIX_TIME
+//#define GPS_FIX_LOCATION
+//#define GPS_FIX_LOCATION_DMS
+//#define GPS_FIX_ALTITUDE
+#define GPS_FIX_SPEED
+//#define GPS_FIX_HEADING
+//#define GPS_FIX_SATELLITES
+//#define GPS_FIX_HDOP
+//#define GPS_FIX_VDOP
+//#define GPS_FIX_PDOP
+//#define GPS_FIX_LAT_ERR
+//#define GPS_FIX_LON_ERR
+//#define GPS_FIX_ALT_ERR
+//#define GPS_FIX_GEOID_HEIGHT
+
+#endif

--- a/NMEAGPS.cpp
+++ b/NMEAGPS.cpp
@@ -1,0 +1,1562 @@
+/**
+ * @file NMEAGPS.cpp
+ * @version 3.0
+ *
+ * @section License
+ * Copyright (C) 2016, SlashDevin
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#include "NMEAGPS.h"
+
+#include <Stream.h>
+
+// Check configurations
+ 
+#if defined( GPS_FIX_LOCATION_DMS ) & \
+    !defined( NMEAGPS_PARSING_SCRATCHPAD )
+
+  // The fractional part of the NMEA minutes can have 5 significant figures.
+  //   This requires more temporary storage than is available in the DMS_t.
+  #error You must enable NMEAGPS_PARSING_SCRATCHPAD in NMEAGPS_cfg.h
+
+#endif
+
+#ifndef CR
+  #define CR ((char)13)
+#endif
+#ifndef LF
+  #define LF ((char)10)
+#endif
+
+/********************************
+ * parseHEX(char a)
+ * Parses a single character as HEX and returns byte value.
+ */
+inline static uint8_t parseHEX(char a)
+{
+  a |= 0x20; // make it lowercase
+  if (('a' <= a) && (a <= 'f'))
+      return a - 'a' + 10;
+  else
+      return a - '0';
+}
+
+/**
+ * formatHEX(char a)
+ * Formats lower nybble of value as HEX and returns character.
+ */
+static char formatHex( uint8_t val )
+{
+  val &= 0x0F;
+  return (val >= 10) ? ((val - 10) + 'A') : (val + '0');
+}
+
+//---------------------------------
+
+inline uint8_t to_binary(uint8_t value)
+{
+  uint8_t high = (value >> 4);
+  uint8_t low = (value & 0x0f);
+  return ((high << 3) + (high << 1) + low);
+}
+
+//---------------------------------
+
+NMEAGPS::NMEAGPS()
+{
+  #ifdef NMEAGPS_STATS
+    statistics.init();
+  #endif
+
+  data_init();
+
+  reset();
+}
+
+/*
+ * Prepare internal members to receive data from sentence fields.
+ */
+void NMEAGPS::sentenceBegin()
+{
+  crc          = 0;
+  nmeaMessage  = NMEA_UNKNOWN;
+  rxState      = NMEA_RECEIVING_HEADER;
+  chrCount     = 0;
+  comma_needed( false );
+
+  #ifdef NMEAGPS_PARSE_PROPRIETARY
+    proprietary  = false;
+
+    #ifdef NMEAGPS_SAVE_MFR_ID
+      mfr_id[0] =
+      mfr_id[1] =
+      mfr_id[2] = 0;
+    #endif
+  #endif
+
+  #ifdef NMEAGPS_SAVE_TALKER_ID
+    talker_id[0] =
+    talker_id[1] = 0;
+  #endif
+}
+
+
+/*
+ * All fields from a sentence have been parsed.
+ */
+
+void NMEAGPS::sentenceOk()
+{
+  // Terminate the last field with a comma if the parser needs it.
+  if (comma_needed()) {
+    comma_needed( false );
+    chrCount++;
+    parseField(',');
+  }
+
+  #ifdef NMEAGPS_STATS
+    statistics.ok++;
+  #endif
+
+  reset();
+}
+
+/**
+ * There was something wrong with the sentence.
+ */
+void NMEAGPS::sentenceInvalid()
+{
+  // All the values are suspect.  Start over.
+  m_fix.valid.init();
+  nmeaMessage = NMEA_UNKNOWN;
+
+  reset();
+}
+
+/**
+ *  The sentence is well-formed, but is an unrecognized type
+ */
+
+void NMEAGPS::sentenceUnrecognized()
+{
+  nmeaMessage = NMEA_UNKNOWN;
+
+  reset();
+}
+
+void NMEAGPS::headerReceived()
+{
+  NMEAGPS_INIT_FIX(m_fix);
+  fieldIndex = 1;
+  chrCount   = 0;
+  rxState    = NMEA_RECEIVING_DATA;
+}
+
+//----------------------------------------------------------------
+// Process one character of an NMEA GPS sentence. 
+
+NMEAGPS::decode_t NMEAGPS::decode( char c )
+{
+  #ifdef NMEAGPS_STATS
+    statistics.chars++;
+  #endif
+
+  decode_t res = DECODE_CHR_OK;
+
+  if (c == '$') {  // Always restarts
+    sentenceBegin();
+
+  } else if (rxState == NMEA_RECEIVING_DATA) { //---------------------------
+    // Receive complete sentence
+
+    if (c == '*') {                // Line finished, CRC follows
+        rxState = NMEA_RECEIVING_CRC;
+        chrCount = 0;
+
+    } else if ((' ' <= c) && (c <= '~')) { // Normal data character
+
+        crc ^= c;  // accumulate CRC as the chars come in...
+
+        if (!parseField( c ))
+          sentenceInvalid();
+        else if (c == ',') {
+          // Start the next field
+          comma_needed( false );
+          fieldIndex++;
+          chrCount     = 0;
+        } else
+          chrCount++;
+
+    // This is an undocumented option.  It could be useful
+    // for testing, but all real devices will output a CS.
+    #ifdef NMEAGPS_CS_OPTIONAL
+      } else if ((c == CR) || (c == LF)) { // Line finished, no CRC
+        sentenceOk();
+        res = DECODE_COMPLETED;
+    #endif
+
+    } else {                           // Invalid char
+      sentenceInvalid();
+      res = DECODE_CHR_INVALID;
+    }
+    
+    
+  } else if (rxState == NMEA_RECEIVING_HEADER) { //------------------------
+
+    //  The first field is the sentence type.  It will be used
+    //  later by the virtual /parseField/.
+
+    crc ^= c;  // accumulate CRC as the chars come in...
+
+    decode_t cmd_res = parseCommand( c );
+
+    if (cmd_res == DECODE_CHR_OK) {
+      chrCount++;
+    } else if (cmd_res == DECODE_COMPLETED) {
+      headerReceived();
+    } else // DECODE_CHR_INVALID
+      sentenceUnrecognized();
+
+
+  } else if (rxState == NMEA_RECEIVING_CRC) { //---------------------------
+    bool    err;
+    uint8_t nybble = parseHEX( c );
+
+    if (chrCount == 0) {
+      chrCount++;
+      err = ((crc >> 4) != nybble);
+    } else { // chrCount == 1
+      err = ((crc & 0x0F) != nybble);
+      if (!err) {
+        sentenceOk();
+        res = DECODE_COMPLETED;
+      }
+    }
+
+    if (err) {
+      #ifdef NMEAGPS_STATS
+        statistics.crc_errors++;
+      #endif
+      sentenceInvalid();
+    }
+
+  } else if (rxState == NMEA_IDLE) { //---------------------------
+    // Reject non-start characters
+
+    res         = DECODE_CHR_INVALID;
+    nmeaMessage = NMEA_UNKNOWN;
+  }
+
+  return res;
+
+} // decode
+
+
+
+//----------------------------------------------------------------
+// NMEA Sentence strings (alphabetical)
+
+#if defined(NMEAGPS_PARSE_GGA) | defined(NMEAGPS_RECOGNIZE_ALL)
+  static const char gga[] __PROGMEM =  "GGA";
+#endif
+#if defined(NMEAGPS_PARSE_GLL) | defined(NMEAGPS_RECOGNIZE_ALL)
+  static const char gll[] __PROGMEM =  "GLL";
+#endif
+#if defined(NMEAGPS_PARSE_GSA) | defined(NMEAGPS_RECOGNIZE_ALL)
+  static const char gsa[] __PROGMEM =  "GSA";
+#endif
+#if defined(NMEAGPS_PARSE_GST) | defined(NMEAGPS_RECOGNIZE_ALL)
+  static const char gst[] __PROGMEM =  "GST";
+#endif
+#if defined(NMEAGPS_PARSE_GSV) | defined(NMEAGPS_RECOGNIZE_ALL)
+  static const char gsv[] __PROGMEM =  "GSV";
+#endif
+#if defined(NMEAGPS_PARSE_RMC) | defined(NMEAGPS_RECOGNIZE_ALL)
+  static const char rmc[] __PROGMEM =  "RMC";
+#endif
+#if defined(NMEAGPS_PARSE_VTG) | defined(NMEAGPS_RECOGNIZE_ALL)
+  static const char vtg[] __PROGMEM =  "VTG";
+#endif
+#if defined(NMEAGPS_PARSE_ZDA) | defined(NMEAGPS_RECOGNIZE_ALL)
+  static const char zda[] __PROGMEM =  "ZDA";
+#endif
+
+static const char * const std_nmea[] __PROGMEM =
+  {
+    #if defined(NMEAGPS_PARSE_GGA) | defined(NMEAGPS_RECOGNIZE_ALL)
+      gga,
+    #endif
+    #if defined(NMEAGPS_PARSE_GLL) | defined(NMEAGPS_RECOGNIZE_ALL)
+      gll,
+    #endif
+    #if defined(NMEAGPS_PARSE_GSA) | defined(NMEAGPS_RECOGNIZE_ALL)
+      gsa,
+    #endif
+    #if defined(NMEAGPS_PARSE_GST) | defined(NMEAGPS_RECOGNIZE_ALL)
+      gst,
+    #endif
+    #if defined(NMEAGPS_PARSE_GSV) | defined(NMEAGPS_RECOGNIZE_ALL)
+      gsv,
+    #endif
+    #if defined(NMEAGPS_PARSE_RMC) | defined(NMEAGPS_RECOGNIZE_ALL)
+      rmc,
+    #endif
+    #if defined(NMEAGPS_PARSE_VTG) | defined(NMEAGPS_RECOGNIZE_ALL)
+      vtg,
+    #endif
+    #if defined(NMEAGPS_PARSE_ZDA) | defined(NMEAGPS_RECOGNIZE_ALL)
+      zda
+    #endif
+  };
+
+const NMEAGPS::msg_table_t NMEAGPS::nmea_msg_table __PROGMEM =
+  {
+    NMEAGPS::NMEA_FIRST_MSG,
+    (const msg_table_t *) NULL,
+    sizeof(std_nmea)/sizeof(std_nmea[0]),
+    std_nmea
+  };
+
+
+NMEAGPS::decode_t NMEAGPS::parseCommand( char c )
+{
+  if (c == ',') {
+    // End of field, did we get a sentence type yet?
+    return
+      (nmeaMessage == NMEA_UNKNOWN) ?
+        DECODE_CHR_INVALID :
+        DECODE_COMPLETED;
+  }
+
+  #ifdef NMEAGPS_PARSE_PROPRIETARY
+    if ((chrCount == 0) && (c == 'P')) {
+      //  Starting a proprietary message...
+      proprietary = true;
+      return DECODE_CHR_OK;
+    }
+  #endif
+  
+  uint8_t cmdCount = chrCount;
+
+  #ifdef NMEAGPS_PARSE_PROPRIETARY
+    if (proprietary) {
+
+      // Next three chars are the manufacturer ID
+      if (chrCount < 4) {
+        #ifdef NMEAGPS_SAVE_MFR_ID
+          mfr_id[chrCount-1] = c;
+        #endif
+
+        #ifdef NMEAGPS_PARSE_MFR_ID
+          if (!parseMfrID( c ))
+            return DECODE_CHR_INVALID;
+        #endif
+
+        return DECODE_CHR_OK;
+      }
+
+      cmdCount -= 4;
+
+    } else
+  #endif
+  { // standard
+
+    // First two chars are talker ID
+    if (chrCount < 2) {
+      #ifdef NMEAGPS_SAVE_TALKER_ID
+        talker_id[chrCount] = c;
+      #endif
+
+      #ifdef NMEAGPS_PARSE_TALKER_ID
+        if (!parseTalkerID( c ))
+          return DECODE_CHR_INVALID;
+      #endif
+
+      return DECODE_CHR_OK;
+    }
+    
+    cmdCount -= 2;
+  }
+
+  //  The remaining characters are the message type.
+
+  const msg_table_t *msgs = msg_table();
+
+  return parseCommand( msgs, cmdCount, c );
+
+} // parseCommand
+
+//---------------------------------------------
+
+NMEAGPS::decode_t NMEAGPS::parseCommand
+  ( const msg_table_t *msgs, uint8_t cmdCount, char c )
+{
+  for (;;) {
+    uint8_t  table_size       = pgm_read_byte( &msgs->size );
+    uint8_t  msg_offset       = pgm_read_byte( &msgs->offset );
+    decode_t res              = DECODE_CHR_INVALID;
+    bool     check_this_table = true;
+    uint8_t  entry;
+
+    if (nmeaMessage == NMEA_UNKNOWN) {
+      // We're just starting
+      entry = 0;
+
+    } else if ((msg_offset <= nmeaMessage) && (nmeaMessage < msg_offset+table_size)) {
+      // In range of this table, pick up where we left off
+      entry = nmeaMessage - msg_offset;
+    }
+    #ifdef NMEAGPS_DERIVED_TYPES
+      else
+        check_this_table = false;
+    #endif
+
+    if (check_this_table) {
+      uint8_t i = entry;
+
+      const char * const *table   = (const char * const *) pgm_read_word( &msgs->table );
+      const char *        table_i = (const char *) pgm_read_word( &table[i] );
+      
+      for (;;) {
+        char rc = pgm_read_byte( &table_i[cmdCount] );
+        if (c == rc) {
+          // ok so far...
+          entry = i;
+          res = DECODE_CHR_OK;
+          break;
+        }
+
+        if (c < rc) {
+          // Alphabetical rejection, check next table
+          break;
+        }
+
+        // Ok to check another entry in this table
+        uint8_t next_msg = i+1;
+        if (next_msg >= table_size) {
+          // No more entries in this table.
+          break;
+        }
+
+        //  See if the next entry starts with the same characters.
+        const char *table_next = (const char *) pgm_read_word( &table[next_msg] );
+        for (uint8_t j = 0; j < cmdCount; j++)
+          if (pgm_read_byte( &table_i[j] ) != pgm_read_byte( &table_next[j] )) {
+            // Nope, a different start to this entry
+            break;
+          }
+        i = next_msg;
+        table_i = table_next;
+      }
+    }
+
+    if (res == DECODE_CHR_INVALID) {
+
+      #ifdef NMEAGPS_DERIVED_TYPES
+        msgs = (const msg_table_t *) pgm_read_word( &msgs->previous );
+        if (msgs) {
+          // Try the current character in the previous table
+          continue;
+        } // else
+          // No more tables, chr is invalid.
+      #endif
+      
+    } else {
+      //  This entry is good so far.
+      nmeaMessage = (nmea_msg_t) (entry + msg_offset);
+    }
+
+    return res;
+  }
+
+} // parseCommand
+
+//---------------------------------------------
+
+const __FlashStringHelper *NMEAGPS::string_for( nmea_msg_t msg ) const
+{
+  if (msg == NMEA_UNKNOWN)
+    return (const __FlashStringHelper *) NULL;
+
+  const msg_table_t *msgs = msg_table();
+
+  for (;;) {
+    uint8_t  table_size       = pgm_read_byte( &msgs->size );
+    uint8_t  msg_offset       = pgm_read_byte( &msgs->offset );
+
+    if ((msg_offset <= msg) && (msg < msg_offset+table_size)) {
+      // In range of this table
+      const char * const *table   = (const char * const *) pgm_read_word( &msgs->table );
+      return
+        (const __FlashStringHelper *) 
+          pgm_read_word( &table[ ((uint8_t)msg) - msg_offset ] );
+    }
+ 
+    #ifdef NMEAGPS_DERIVED_TYPES
+      // Try the previous table
+      msgs = (const msg_table_t *) pgm_read_word( &msgs->previous );
+      if (msgs)
+        continue;
+    #endif
+
+    return (const __FlashStringHelper *)  NULL;
+  }
+
+} // string_for
+
+//---------------------------------------------
+
+bool NMEAGPS::parseField(char chr)
+{
+    switch (nmeaMessage) {
+
+      #if defined(NMEAGPS_PARSE_GGA)
+        case NMEA_GGA: return parseGGA( chr );
+      #endif
+
+      #if defined(NMEAGPS_PARSE_GLL)
+        case NMEA_GLL: return parseGLL( chr );
+      #endif
+
+      #if defined(NMEAGPS_PARSE_GSA)
+        case NMEA_GSA: return parseGSA( chr );
+      #endif
+
+      #if defined(NMEAGPS_PARSE_GST)
+        case NMEA_GST: return parseGST( chr );
+      #endif
+
+      #if defined(NMEAGPS_PARSE_GSV)
+        case NMEA_GSV: return parseGSV( chr );
+      #endif
+
+      #if defined(NMEAGPS_PARSE_RMC)
+        case NMEA_RMC: return parseRMC( chr );
+      #endif
+
+      #if defined(NMEAGPS_PARSE_VTG)
+        case NMEA_VTG: return parseVTG( chr );
+      #endif
+
+      #if defined(NMEAGPS_PARSE_ZDA)
+        case NMEA_ZDA: return parseZDA( chr );
+      #endif
+
+      default:
+          break;
+    }
+
+    return true;
+
+} // parseField
+
+//---------------------------------
+
+bool NMEAGPS::parseGGA( char chr )
+{
+  #ifdef NMEAGPS_PARSE_GGA
+    switch (fieldIndex) {
+        case  1: return parseTime( chr );
+        PARSE_LOC(2);
+        case  6: return parseFix( chr );
+        case  7: return parseSatellites( chr );
+        case  8: return parseHDOP( chr );
+        case  9: return parseAlt( chr );
+        case 11: return parseGeoidHeight( chr );
+    }
+  #endif
+
+  return true;
+
+} // parseGGA
+
+//---------------------------------
+
+bool NMEAGPS::parseGLL( char chr )
+{
+  #ifdef NMEAGPS_PARSE_GLL
+    switch (fieldIndex) {
+        PARSE_LOC(1);
+        case 5: return parseTime( chr );
+        case 7: return parseFix( chr );
+    }
+  #endif
+
+  return true;
+
+} // parseGLL
+
+//---------------------------------
+
+bool NMEAGPS::parseGSA( char chr )
+{
+  #ifdef NMEAGPS_PARSE_GSA
+
+    switch (fieldIndex) {
+      case 2:
+        if (chrCount == 0) {
+          if ((chr == '2') || (chr == '3')) {
+            m_fix.status = gps_fix::STATUS_STD;
+            m_fix.valid.status = true;
+          } else if (chr == '1') {
+            m_fix.status = gps_fix::STATUS_NONE;
+            m_fix.valid.status = true;
+          }
+        }
+        break;
+
+      case 15: return parsePDOP( chr );
+      case 16: return parseHDOP( chr );
+      case 17: return parseVDOP( chr );
+
+      #ifdef NMEAGPS_PARSE_SATELLITES
+
+        // It's not clear how this sentence relates to GSV.  GSA
+        // only allows 12 satellites, while GSV allows any number.  
+        // In the absence of guidance, GSV shall have priority 
+        // over GSA with repect to populating the satellites
+        // array.  Ignore the satellite fields if GSV is enabled.
+
+        #ifndef NMEAGPS_PARSE_GSV
+
+          case 1: break; // allows "default:" case for SV fields
+          case 3:
+            if (chrCount == 0) {
+              NMEAGPS_INVALIDATE( satellites );
+              m_fix.satellites = 0;
+              sat_count = 0;
+            }
+          default:
+            if (chr == ',') {
+              if (chrCount > 0) {
+                m_fix.valid.satellites = true;
+                m_fix.satellites++;
+                sat_count = m_fix.satellites;
+              }
+            } else
+              parseInt( satellites[m_fix.satellites].id, chr );
+            break;
+        #endif
+      #endif
+    }
+  #endif
+
+  return true;
+
+} // parseGSA
+
+//---------------------------------
+
+bool NMEAGPS::parseGST( char chr )
+{
+  #ifdef NMEAGPS_PARSE_GST
+    switch (fieldIndex) {
+      case 1: return parseTime( chr );
+      case 6: return parse_lat_err( chr );
+      case 7: return parse_lon_err( chr );
+      case 8: return parse_alt_err( chr );
+    }
+  #endif
+
+  return true;
+
+} // parseGST
+
+//---------------------------------
+
+bool NMEAGPS::parseGSV( char chr )
+{
+  #ifdef NMEAGPS_PARSE_GSV
+
+    switch (fieldIndex) {
+        case 3: return parseSatellites( chr );
+
+        #ifdef NMEAGPS_PARSE_SATELLITES
+          case 1:
+            // allows "default:" case for SV fields
+            break;
+          case 2: // GSV message number (e.g., 2nd of n)
+            if (chr != ',')
+              // sat_count is temporarily used to hold the MsgNo...
+              parseInt( sat_count, chr );
+            else
+              // ...then it's converted to the real sat_count
+              // based on up to 4 satellites per msg.
+              sat_count = (sat_count - 1) * 4;
+            break;
+
+          default:
+            if (sat_count < NMEAGPS_MAX_SATELLITES) {
+
+              switch (fieldIndex % 4) {
+                #ifdef NMEAGPS_PARSE_SATELLITE_INFO
+                  case 0: parseInt( satellites[sat_count].id       , chr ); break;
+                  case 1: parseInt( satellites[sat_count].elevation, chr ); break;
+                  case 2:
+                    if (chr != ',')
+                      parseInt( satellites[sat_count].azimuth, chr );
+                    else
+                      sat_count++; // field 3 can be omitted, increment now
+                    break;
+                  case 3:
+                    if (chr != ',') {
+                      uint8_t snr = satellites[sat_count-1].snr;
+                      parseInt( snr, chr );
+                      satellites[sat_count-1].snr = snr;
+                    } else
+                      satellites[sat_count-1].tracked = (chrCount != 0);
+                    break;
+                #else
+                  case 0:
+                    if (chr != ',')
+                      parseInt( satellites[sat_count].id, chr );
+                    else
+                      sat_count++;
+                    break;
+                #endif
+              }
+            }
+        #endif
+    }
+  #endif
+
+  return true;
+
+} // parseGSV
+
+//---------------------------------
+
+bool NMEAGPS::parseRMC( char chr )
+{
+  #ifdef NMEAGPS_PARSE_RMC
+    switch (fieldIndex) {
+      case 1:  return parseTime   ( chr );
+      case 2:  return parseFix    ( chr );
+      PARSE_LOC(3);
+      case 7:  return parseSpeed  ( chr );
+      case 8:  return parseHeading( chr );
+      case 9:  return parseDDMMYY ( chr );
+      case 12: return parseFix    ( chr );
+    }
+  #endif
+
+  return true;
+
+} // parseRMC
+
+//---------------------------------
+
+bool NMEAGPS::parseVTG( char chr )
+{
+  #ifdef NMEAGPS_PARSE_VTG
+    switch (fieldIndex) {
+      case 1: return parseHeading( chr );
+      case 5: return parseSpeed( chr );
+      case 9: return parseFix( chr );
+    }
+  #endif
+
+  return true;
+
+} // parseVTG
+
+//---------------------------------
+
+bool NMEAGPS::parseZDA( char chr )
+{
+  #ifdef NMEAGPS_PARSE_ZDA
+    switch (fieldIndex) {
+      case 1: return parseTime( chr );
+
+      #ifdef GPS_FIX_DATE
+        case 2:
+          if (chrCount == 0)
+            NMEAGPS_INVALIDATE( date );
+          parseInt( m_fix.dateTime.date , chr );
+          break;
+        case 3: parseInt( m_fix.dateTime.month, chr ); break;
+        case 4:
+          if (chr != ',') {
+            // year is BCD until terminating comma.
+            //   This essentially keeps the last two digits
+            if (chrCount == 0) {
+              comma_needed( true );
+              m_fix.dateTime.year = (chr - '0');
+            } else
+              m_fix.dateTime.year = (m_fix.dateTime.year << 4) + (chr - '0');
+          } else {
+            m_fix.dateTime.year = to_binary( m_fix.dateTime.year );
+            m_fix.valid.date = true;
+          }
+          break;
+      #endif
+    }
+  #endif
+
+  return true;
+
+} // parseZDA
+
+//---------------------------------
+
+bool NMEAGPS::parseTime(char chr)
+{
+  #ifdef GPS_FIX_TIME
+    switch (chrCount) {
+      case 0: NMEAGPS_INVALIDATE( time );
+              m_fix.dateTime.hours    = (chr - '0')*10; break;
+      case 1: m_fix.dateTime.hours   += (chr - '0');    break;
+      case 2: m_fix.dateTime.minutes  = (chr - '0')*10; break;
+      case 3: m_fix.dateTime.minutes += (chr - '0');    break;
+      case 4: m_fix.dateTime.seconds  = (chr - '0')*10; break;
+      case 5: m_fix.dateTime.seconds += (chr - '0');    break;
+      case 7: m_fix.dateTime_cs       = (chr - '0')*10; break;
+      case 8: m_fix.dateTime_cs      += (chr - '0');
+              m_fix.valid.time = true;
+              break;
+    }
+  #endif
+
+  return true;
+
+} // parseTime
+
+//---------------------------------
+
+bool NMEAGPS::parseDDMMYY( char chr )
+{
+  #ifdef GPS_FIX_DATE
+    switch (chrCount) {
+      case 0: NMEAGPS_INVALIDATE( date );
+              m_fix.dateTime.date   = (chr - '0')*10; break;
+      case 1: m_fix.dateTime.date  += (chr - '0');    break;
+      case 2: m_fix.dateTime.month  = (chr - '0')*10; break;
+      case 3: m_fix.dateTime.month += (chr - '0');    break;
+      case 4: m_fix.dateTime.year   = (chr - '0')*10; break;
+      case 5: m_fix.dateTime.year  += (chr - '0');
+              m_fix.valid.date = true;
+              break;
+    }
+  #endif
+
+  return true;
+
+} // parseDDMMYY
+
+//---------------------------------
+
+bool NMEAGPS::parseFix( char chr )
+{
+  if (chrCount == 0) {
+    NMEAGPS_INVALIDATE( status );
+    bool ok = true;
+    if ((chr == '1') || (chr == 'A'))
+      m_fix.status = gps_fix::STATUS_STD;
+    else if ((chr == '0') || (chr == 'N') || (chr == 'V'))
+      m_fix.status = gps_fix::STATUS_NONE;
+    else if ((chr == '2') || (chr == 'D'))
+      m_fix.status = gps_fix::STATUS_DGPS;
+    else if ((chr == '6') || (chr == 'E'))
+      m_fix.status = gps_fix::STATUS_EST;
+    else
+      ok = false;
+    if (ok)
+      m_fix.valid.status = true;
+  }
+
+  return true;
+
+} // parseFix
+
+//---------------------------------
+
+bool NMEAGPS::parseFloat
+  ( gps_fix::whole_frac & val, char chr, uint8_t max_decimal )
+{
+  bool done = false;
+  
+  if (chrCount == 0) {
+    val.init();
+    comma_needed( true );
+    decimal      = 0;
+    negative     = (chr == '-');
+    if (negative) return done;
+  }
+
+  if (chr == ',') {
+    // End of field, make sure it's scaled up
+    if (!decimal)
+      decimal = 1;
+    if (val.frac)
+      while (decimal++ <= max_decimal)
+        val.frac *= 10;
+    if (negative) {
+      val.frac  = -val.frac;
+      val.whole = -val.whole;
+    }
+    done = true;
+  } else if (chr == '.') {
+    decimal = 1;
+  } else if (!decimal) {
+    val.whole = val.whole*10 + (chr - '0');
+  } else if (decimal++ <= max_decimal) {
+    val.frac = val.frac*10 + (chr - '0');
+  }
+
+  return done;
+
+} // parseFloat
+
+//---------------------------------
+
+bool NMEAGPS::parseFloat( uint16_t & val, char chr, uint8_t max_decimal )
+{
+  bool done = false;
+
+  if (chrCount == 0) {
+    val          = 0;
+    comma_needed( true );
+    decimal      = 0;
+    negative     = (chr == '-');
+    if (negative) return done;
+  }
+
+  if (chr == ',') {
+    if (val)
+      while (decimal++ <= max_decimal)
+        val *= 10;
+    if (negative)
+      val = -val;
+    done = true;
+  } else if (chr == '.')
+    decimal = 1;
+  else if (decimal++ <= max_decimal)
+    val = val*10 + (chr - '0');
+
+  return done;
+
+} // parseFloat
+
+//---------------------------------------------------
+
+#ifdef GPS_FIX_LOCATION_DMS
+
+  static void finalizeDMS( uint32_t min_frac, DMS_t & dms )
+  {
+    // To convert from fractional minutes (hundred thousandths) to 
+    //   seconds_whole and seconds_frac,
+    //
+    //   seconds = min_frac * 60/100000
+    //           = min_frac * 0.0006
+
+    #ifdef __AVR__
+      // Fixed point conversion factor 0.0006 * 2^26 = 40265
+      const uint32_t to_seconds_E26 = 40265UL;
+
+      uint32_t secs_E26      = min_frac * to_seconds_E26;
+      uint8_t  secs          = secs_E26 >> 26;
+      uint32_t remainder_E26 = secs_E26 - (((uint32_t) secs) << 26);
+
+      // thousandths = (rem_E26 * 1000) >> 26;
+      //             = (rem_E26 *  125) >> 23;             // 1000 = (125 << 3)
+      //             = ((rem_E26 >> 8) * 125) >> 15;       // avoid overflow
+      //             = (((rem_E26 >> 8) * 125) >> 8) >> 7; // final shift 15 in two steps
+      //             = ((((rem_E26 >> 8) * 125) >> 8) + 72) >> 7;
+      //                                                   // round up
+      uint16_t frac_x1000   = ((((remainder_E26 >> 8) * 125UL) >> 8) + 64) >> 7;
+
+    #else // not __AVR__
+
+      min_frac *= 6UL;
+      uint32_t secs       = min_frac / 10000UL;
+      uint16_t frac_x1000 = (min_frac - (secs * 10000UL) + 5) / 10;
+
+    #endif
+
+    // Rounding up can yield a frac of 1000/1000ths. Carry into whole.
+    if (frac_x1000 >= 1000) {
+      frac_x1000 -= 1000;
+      secs       += 1;
+    }
+    dms.seconds_whole  = secs;
+    dms.seconds_frac   = frac_x1000;
+
+  } // finalizeDMS
+
+#endif
+
+//.................................................
+// From http://www.hackersdelight.org/divcMore.pdf
+
+static uint32_t divu3( uint32_t n )
+{
+  #ifdef __AVR__
+    uint32_t q = (n >> 2) + (n >> 4); // q = n*0.0101 (approx).
+    q = q + (q >> 4); // q = n*0.01010101.
+    q = q + (q >> 8);
+    q = q + (q >> 16);
+
+    uint32_t r = n - q*3; // 0 <= r <= 15.
+    return q + (11*r >> 5); // Returning q + r/3.
+  #else
+    return n/3;
+  #endif
+}
+
+//.................................................
+// Parse lat/lon dddmm.mmmm fields
+
+bool NMEAGPS::parseDDDMM
+  (
+    #if defined( GPS_FIX_LOCATION )
+      int32_t & val,
+    #endif
+    #if defined( GPS_FIX_LOCATION_DMS )
+      DMS_t & dms,
+    #endif
+    char chr
+  )
+{
+  #if defined( GPS_FIX_LOCATION ) | defined( GPS_FIX_LOCATION_DMS )
+
+    if (chrCount == 0) {
+      #ifdef GPS_FIX_LOCATION
+        val        = 0;
+      #endif
+      #ifdef GPS_FIX_LOCATION_DMS
+        dms.init();
+      #endif
+      decimal      = 0;
+      comma_needed( true );
+    }
+    
+    if ((chr == '.') || ((chr == ',') && !decimal)) {
+      // Now we know how many digits are in degrees; all but the last two.
+      // Switch from BCD (digits) to binary minutes.
+      decimal = 1;
+      #ifdef GPS_FIX_LOCATION
+        uint8_t *valBCD = (uint8_t *) &val;
+      #else
+        uint8_t *valBCD = (uint8_t *) &dms;
+      #endif
+      uint8_t  deg     = to_binary( valBCD[1] );
+      if (valBCD[2] != 0)
+        deg += 100; // only possible if abs(longitude) >= 100.0 degrees
+
+      // Convert val to minutes
+      uint8_t min = to_binary( valBCD[0] );
+      #ifdef GPS_FIX_LOCATION
+        val = (deg * 60) + min;
+      #endif
+      #ifdef GPS_FIX_LOCATION_DMS
+        dms.degrees   = deg;
+        dms.minutes   = min;
+        scratchpad.U4 = 0;
+      #endif
+
+      if (chr == '.') return true;
+    }
+
+    if (chr == ',') {
+      // If the last chars in ".mmmmmm" were not received,
+      //    force the value into its final state.
+
+      #ifdef GPS_FIX_LOCATION_DMS
+        if (decimal <= 5) {
+          if (decimal == 5)
+            scratchpad.U4 *= 10;
+          else if (decimal == 4)
+            scratchpad.U4 *= 100;
+          else if (decimal == 3)
+            scratchpad.U4 *= 1000;
+          else if (decimal == 2)
+            scratchpad.U4 *= 10000;
+
+          finalizeDMS( scratchpad.U4, dms );
+        }
+      #endif
+
+      #ifdef GPS_FIX_LOCATION
+        if (decimal == 4)
+          val *= 100;
+        else if (decimal == 5)
+          val *= 10;
+        else if (decimal == 6)
+          ;
+        else if (decimal > 6)
+          return true; // already converted at decimal==7
+        else if (decimal == 3)
+          val *= 1000;
+        else if (decimal == 2)
+          val *= 10000;
+        else if (decimal == 1)
+          val *= 100000;
+
+        // Convert minutes x 1000000 to degrees x 10000000.
+        val += divu3(val*2 + 1); // same as 10 * ((val+30)/60) without trunc
+      #endif
+
+    } else if (!decimal) {
+
+      // BCD until *after* decimal point
+
+      #ifdef GPS_FIX_LOCATION
+        val = (val<<4) | (chr - '0');
+      #else
+        uint32_t *val = (uint32_t *) &dms;
+        *val = (*val<<4) | (chr - '0');
+      #endif
+
+    } else {
+
+      decimal++;
+
+      #ifdef GPS_FIX_LOCATION_DMS
+        if (decimal <= 6) {
+          scratchpad.U4 = scratchpad.U4 * 10 + (chr - '0');
+          if (decimal == 6)
+            finalizeDMS( scratchpad.U4, dms );
+        }
+      #endif
+
+      #ifdef GPS_FIX_LOCATION
+        if (decimal <= 6) {
+
+          val = val*10 + (chr - '0');
+
+        } else if (decimal == 7) {
+
+          // Convert now, while we still have the 6th decimal digit
+          val += divu3(val*2 + 1); // same as 10 * ((val+30)/60) without trunc
+          if (chr >= '9')
+            val += 2;
+          else if (chr >= '4')
+            val += 1;
+        }
+      #endif
+    }
+
+  #endif
+
+  return true;
+
+} // parseDDDMM
+
+//---------------------------------
+
+bool NMEAGPS::parseLat( char chr )
+{
+  #if defined( GPS_FIX_LOCATION ) | defined( GPS_FIX_LOCATION_DMS )
+    if (chrCount == 0) {
+      group_valid = (chr != ',');
+      if (group_valid)
+        NMEAGPS_INVALIDATE( location );
+    }
+
+    if (group_valid) {
+      parseDDDMM
+        (
+          #if defined( GPS_FIX_LOCATION )
+            m_fix.lat, 
+          #endif
+          #if defined( GPS_FIX_LOCATION_DMS )
+            m_fix.latitudeDMS,
+          #endif
+          chr
+        );
+    }
+  #endif
+
+  return true;
+}
+
+bool NMEAGPS::parseNS( char chr )
+{
+  #if defined( GPS_FIX_LOCATION ) | defined( GPS_FIX_LOCATION_DMS )
+    if (group_valid && (chr == 'S')) {
+      #ifdef GPS_FIX_LOCATION
+        m_fix.lat = -m_fix.lat;
+      #endif
+      #ifdef GPS_FIX_LOCATION_DMS
+        m_fix.latitudeDMS.hemisphere = SOUTH_H;
+      #endif
+    }
+  #endif
+
+  return true;
+}
+
+bool NMEAGPS::parseLon( char chr )
+{
+  #if defined( GPS_FIX_LOCATION ) | defined( GPS_FIX_LOCATION_DMS )
+    if ((chr == ',') && (chrCount == 0))
+      group_valid = false;
+
+    if (group_valid) {
+      parseDDDMM
+        (
+          #if defined( GPS_FIX_LOCATION )
+            m_fix.lon, 
+          #endif
+          #if defined( GPS_FIX_LOCATION_DMS )
+            m_fix.longitudeDMS,
+          #endif
+          chr
+        );
+    }
+  #endif
+
+  return true;
+}
+
+bool NMEAGPS::parseEW( char chr )
+{
+  #if defined( GPS_FIX_LOCATION ) | defined( GPS_FIX_LOCATION_DMS )
+    if (group_valid) {
+      if (chr == 'W') {
+        #ifdef GPS_FIX_LOCATION
+          m_fix.lon = -m_fix.lon;
+        #endif
+        #ifdef GPS_FIX_LOCATION_DMS
+          m_fix.longitudeDMS.hemisphere = WEST_H;
+        #endif
+      }
+      m_fix.valid.location = true;
+    }
+  #endif
+  
+  return true;
+}
+
+//---------------------------------
+
+bool NMEAGPS::parseSpeed( char chr )
+{
+  #ifdef GPS_FIX_SPEED
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( speed );
+    if (parseFloat( m_fix.spd, chr, 3 ))
+      m_fix.valid.speed = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parseSpeed
+
+//---------------------------------
+
+bool NMEAGPS::parseHeading( char chr )
+{
+  #ifdef GPS_FIX_HEADING
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( heading );
+    if (parseFloat( m_fix.hdg, chr, 2 ))
+      m_fix.valid.heading = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parseHeading
+
+//---------------------------------
+
+bool NMEAGPS::parseAlt(char chr )
+{
+  #ifdef GPS_FIX_ALTITUDE
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( altitude );
+    if (parseFloat( m_fix.alt, chr, 2 ))
+      m_fix.valid.altitude = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parseAlt
+
+//---------------------------------
+
+bool NMEAGPS::parseGeoidHeight( char chr )
+{
+  #ifdef GPS_FIX_GEOID_HEIGHT
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( geoidHeight );
+    if (parseFloat( m_fix.geoidHt, chr, 2 ))
+      m_fix.valid.geoidHeight = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parseGeoidHeight
+
+//---------------------------------
+
+bool NMEAGPS::parseSatellites( char chr )
+{
+  #ifdef GPS_FIX_SATELLITES
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( satellites );
+    if (parseInt( m_fix.satellites, chr )) {
+      m_fix.valid.satellites = true;
+    }
+  #endif
+
+  return true;
+
+} // parseSatellites
+
+//---------------------------------
+
+bool NMEAGPS::parseHDOP( char chr )
+{
+  #ifdef GPS_FIX_HDOP
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( hdop );
+    if (parseFloat( m_fix.hdop, chr, 3 ))
+      m_fix.valid.hdop = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parseHDOP
+
+//---------------------------------
+
+bool NMEAGPS::parseVDOP( char chr )
+{
+  #ifdef GPS_FIX_VDOP
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( vdop );
+    if (parseFloat( m_fix.vdop, chr, 3 ))
+      m_fix.valid.vdop = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parseVDOP
+
+//---------------------------------
+
+bool NMEAGPS::parsePDOP( char chr )
+{
+  #ifdef GPS_FIX_PDOP
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( pdop );
+    if (parseFloat( m_fix.pdop, chr, 3 ))
+      m_fix.valid.pdop = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parsePDOP
+
+//---------------------------------
+
+bool NMEAGPS::parse_lat_err( char chr )
+{
+  #ifdef GPS_FIX_LAT_ERR
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( lat_err );
+    if (parseFloat( m_fix.lat_err_cm, chr, 2 ))
+      m_fix.valid.lat_err = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parse_lat_err
+
+//---------------------------------
+
+bool NMEAGPS::parse_lon_err( char chr )
+{
+  #ifdef GPS_FIX_LON_ERR
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( lon_err );
+    if (parseFloat( m_fix.lon_err_cm, chr, 2 ))
+      m_fix.valid.lon_err = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parse_lon_err
+
+//---------------------------------
+
+bool NMEAGPS::parse_alt_err( char chr )
+{
+  #ifdef GPS_FIX_ALT_ERR
+    if (chrCount == 0)
+      NMEAGPS_INVALIDATE( alt_err );
+    if (parseFloat( m_fix.alt_err_cm, chr, 2 ))
+      m_fix.valid.alt_err = (chrCount != 0);
+  #endif
+
+  return true;
+
+} // parse_alt_err
+
+//---------------------------------
+
+const gps_fix & NMEAGPS::read()
+{
+  if (_fixesAvailable) {
+
+    #if (NMEAGPS_FIX_MAX > 0)
+      lock();
+        _fixesAvailable--;
+        uint8_t i = _firstFix++;
+        if (_firstFix >= NMEAGPS_FIX_MAX)
+          _firstFix = 0;
+      unlock();
+      return buffer[i];
+    #else
+      _fixesAvailable = false;
+      return m_fix;
+    #endif
+
+  } else
+    return m_fix;
+} // read
+
+//---------------------------------
+
+void NMEAGPS::poll( Stream *device, nmea_msg_t msg )
+{
+  //  Only the ublox documentation references talker ID "EI".  
+  //  Other manufacturer's devices use "II" and "GP" talker IDs for the GPQ sentence.
+  //  However, "GP" is reserved for the GPS device, so it seems inconsistent
+  //  to use that talker ID when requesting something from the GPS device.
+
+  #if defined(NMEAGPS_PARSE_GGA) | defined(NMEAGPS_RECOGNIZE_ALL)
+    static const char gga[] __PROGMEM = "EIGPQ,GGA";
+  #endif
+  #if defined(NMEAGPS_PARSE_GLL) | defined(NMEAGPS_RECOGNIZE_ALL)
+    static const char gll[] __PROGMEM = "EIGPQ,GLL";
+  #endif
+  #if defined(NMEAGPS_PARSE_GSA) | defined(NMEAGPS_RECOGNIZE_ALL)
+    static const char gsa[] __PROGMEM = "EIGPQ,GSA";
+  #endif
+  #if defined(NMEAGPS_PARSE_GST) | defined(NMEAGPS_RECOGNIZE_ALL)
+    static const char gst[] __PROGMEM = "EIGPQ,GST";
+  #endif
+  #if defined(NMEAGPS_PARSE_GSV) | defined(NMEAGPS_RECOGNIZE_ALL)
+    static const char gsv[] __PROGMEM = "EIGPQ,GSV";
+  #endif
+  #if defined(NMEAGPS_PARSE_RMC) | defined(NMEAGPS_RECOGNIZE_ALL)
+    static const char rmc[] __PROGMEM = "EIGPQ,RMC";
+  #endif
+  #if defined(NMEAGPS_PARSE_VTG) | defined(NMEAGPS_RECOGNIZE_ALL)
+    static const char vtg[] __PROGMEM = "EIGPQ,VTG";
+  #endif
+  #if defined(NMEAGPS_PARSE_ZDA) | defined(NMEAGPS_RECOGNIZE_ALL)
+    static const char zda[] __PROGMEM = "EIGPQ,ZDA";
+  #endif
+
+  static const char * const poll_msgs[] __PROGMEM =
+    {
+      #if defined(NMEAGPS_PARSE_GGA) | defined(NMEAGPS_RECOGNIZE_ALL)
+        gga,
+      #endif
+      #if defined(NMEAGPS_PARSE_GLL) | defined(NMEAGPS_RECOGNIZE_ALL)
+        gll,
+      #endif
+      #if defined(NMEAGPS_PARSE_GSA) | defined(NMEAGPS_RECOGNIZE_ALL)
+        gsa,
+      #endif
+      #if defined(NMEAGPS_PARSE_GST) | defined(NMEAGPS_RECOGNIZE_ALL)
+        gst,
+      #endif
+      #if defined(NMEAGPS_PARSE_GSV) | defined(NMEAGPS_RECOGNIZE_ALL)
+        gsv,
+      #endif
+      #if defined(NMEAGPS_PARSE_RMC) | defined(NMEAGPS_RECOGNIZE_ALL)
+        rmc,
+      #endif
+      #if defined(NMEAGPS_PARSE_VTG) | defined(NMEAGPS_RECOGNIZE_ALL)
+        vtg,
+      #endif
+      #if defined(NMEAGPS_PARSE_ZDA) | defined(NMEAGPS_RECOGNIZE_ALL)
+        zda
+      #endif
+    };
+
+  if ((NMEA_FIRST_MSG <= msg) && (msg <= NMEA_LAST_MSG)) {
+    const __FlashStringHelper * pollCmd =
+      (const __FlashStringHelper *) pgm_read_word(&poll_msgs[msg-NMEA_FIRST_MSG]);
+    send_P( device, pollCmd );
+  }
+
+} // poll
+
+//---------------------------------
+
+static void send_trailer( Stream *device, uint8_t crc )
+{
+  device->print('*');
+
+  char hexDigit = formatHex( crc>>4 );
+  device->print( hexDigit );
+
+  hexDigit = formatHex( crc );
+  device->print( hexDigit );
+
+  device->print( CR );
+  device->print( LF );
+}
+
+//---------------------------------
+
+void NMEAGPS::send( Stream *device, const char *msg )
+{
+  if (msg && *msg) {
+    device->print('$');
+    if (*msg == '$')
+      msg++;
+    uint8_t sent_trailer = 0;
+    uint8_t crc = 0;
+    while (*msg) {
+      crc ^= *msg;
+      if (*msg == '*' || (sent_trailer > 0))
+        sent_trailer++;
+      device->print( *msg++ );
+    }
+
+    if (sent_trailer != 3)
+      send_trailer( device, crc );
+  }
+
+} // send
+
+//---------------------------------
+
+void NMEAGPS::send_P( Stream *device, const __FlashStringHelper *msg )
+{
+  if (msg) {
+    const char *ptr = (const char *)msg;
+    char chr = pgm_read_byte(ptr++);
+    if (chr && (chr != '$'))
+      device->print('$');
+    uint8_t sent_trailer = 0;
+    uint8_t crc = 0;
+    while (chr) {
+      crc ^= chr;
+      if ((chr == '*') || (sent_trailer > 0))
+        sent_trailer++;
+      device->print( chr );
+      chr = pgm_read_byte(ptr++);
+    }
+
+    if (sent_trailer != 3)
+      send_trailer( device, crc );
+  }
+
+} // send_P

--- a/NMEAGPS.h
+++ b/NMEAGPS.h
@@ -1,0 +1,681 @@
+#ifndef NMEAGPS_H
+#define NMEAGPS_H
+
+//------------------------------------------------------
+// @file NMEAGPS.h
+// @version 3.0
+//
+// @section License
+// Copyright (C) 2016, SlashDevin
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+
+#include "CosaCompat.h"
+
+class __FlashStringHelper;
+#include <Stream.h>
+#include <avr/interrupt.h>
+
+#include "GPSfix.h"
+#include "NMEAGPS_cfg.h"
+
+//------------------------------------------------------
+//
+// NMEA 0183 Parser for generic GPS Modules.  As bytes are received from
+// the device, they affect the internal FSM and set various members
+// of the current /fix/.  As multiple sentences are received, they are 
+// (optionally) merged into a single fix.  When the last sentence in a 
+// time interval (usually 1 second) is received, the fix is stored in the 
+// (optional) buffer of fixes.
+//
+// @section Limitations
+// 1) Only these NMEA messages are parsed:
+//      GGA, GLL, GSA, GST, GSV, RMC, VTG, and ZDA.
+// 2) The current `fix` is only safe to access _after_ the complete message 
+//      is parsed and _before_ the next message begins to affect the members. 
+//      If you access `fix` at any other time, /is_safe()/ must be checked. 
+//      Otherwise, you should make a copy of `fix` after a sentence has been
+//      completely DECODED.
+//
+
+class NMEAGPS
+{
+    NMEAGPS & operator =( const NMEAGPS & );
+    NMEAGPS( const NMEAGPS & );
+
+public:
+
+    NMEAGPS();
+
+    //.......................................................................
+    // The available(...) functions return the number of *fixes* that
+    //   are available to be "read" from the fix buffer.  The GPS port
+    //   object is passed in so a char can be read if port.available().
+
+    uint8_t available( Stream & port )
+      {
+        while (port.available())
+          _handle( port.read() );
+        return _available();
+      }
+    uint8_t available() { return _available(); };
+
+    //.......................................................................
+    // Return the next available fix.  When no more
+    //   fixes are available, it returns the current fix(), which
+    //   may not be completed yet.
+
+    const gps_fix & read();
+    
+    // The typical sketch should have something like this in loop():
+    //
+    //    while (gps.available( Serial1 )) {
+    //      gps_fix fix = gps.read();
+    //      if (fix.valid.location) {
+    //         ...
+    //      }
+    //    }
+
+    //.......................................................................
+    // Instead of using the fix-oriented available() and read() methods,
+    //   you can use the character-oriented method decode().  This may
+    //   be necessary if the source of GPS characters is not a Stream,
+    //   or if you want finer control on how fix information is filtered
+    //   or merged.
+
+    // Return type for /decode/.  As bytes are processed, they can be
+    // categorized as INVALID (not part of this protocol), OK (accepted),
+    // or COMPLETED (end-of-message).
+
+    enum decode_t { DECODE_CHR_INVALID, DECODE_CHR_OK, DECODE_COMPLETED };
+
+    //.......................................................................
+    // Process one character of an NMEA GPS sentence.  The internal state 
+    // machine tracks what part of the sentence has been received.  As the
+    // tracks what part of the sentence has been received so far.  As the
+    // sentence is received, members of the /fix/ structure are updated.  
+    // @return DECODE_COMPLETED when a sentence has been completely received.
+
+    NMEAGPS_VIRTUAL decode_t decode( char c );
+
+    //.......................................................................
+
+    enum merging_t { NO_MERGING, EXPLICIT_MERGING, IMPLICIT_MERGING };
+    static const merging_t
+      merging = NMEAGPS_MERGING; // see NMEAGPS_cfg.h
+
+    enum processing_style_t { PS_POLLING, PS_INTERRUPT };
+    static const processing_style_t 
+      processing_style = NMEAGPS_PROCESSING_STYLE;  // see NMEAGPS_cfg.h
+
+    //.......................................................................
+    //  This routine can be called from the attachInterrupt routine
+
+    #ifdef NMEAGPS_INTERRUPT_PROCESSING
+      void isr( uint8_t c ) { _handle( c ); };
+    #endif
+
+    //.......................................................................
+    // NMEA standard message types (aka "sentences")
+
+    enum nmea_msg_t {
+        NMEA_UNKNOWN,
+
+        #if defined(NMEAGPS_PARSE_GGA) | defined(NMEAGPS_RECOGNIZE_ALL)
+          NMEA_GGA,
+        #endif
+        
+        #if defined(NMEAGPS_PARSE_GLL) | defined(NMEAGPS_RECOGNIZE_ALL)
+          NMEA_GLL,
+        #endif
+        
+        #if defined(NMEAGPS_PARSE_GSA) | defined(NMEAGPS_RECOGNIZE_ALL)
+          NMEA_GSA,
+        #endif
+        
+        #if defined(NMEAGPS_PARSE_GST) | defined(NMEAGPS_RECOGNIZE_ALL)
+          NMEA_GST,
+        #endif
+        
+        #if defined(NMEAGPS_PARSE_GSV) | defined(NMEAGPS_RECOGNIZE_ALL)
+          NMEA_GSV,
+        #endif
+        
+        #if defined(NMEAGPS_PARSE_RMC) | defined(NMEAGPS_RECOGNIZE_ALL)
+          NMEA_RMC,
+        #endif
+        
+        #if defined(NMEAGPS_PARSE_VTG) | defined(NMEAGPS_RECOGNIZE_ALL)
+          NMEA_VTG,
+        #endif
+        
+        #if defined(NMEAGPS_PARSE_ZDA) | defined(NMEAGPS_RECOGNIZE_ALL)
+          NMEA_ZDA,
+        #endif
+        
+        NMEAMSG_END // a bookend that tells how many enums there were
+      };
+
+    CONST_CLASS_DATA nmea_msg_t NMEA_FIRST_MSG = (nmea_msg_t) 1;
+    CONST_CLASS_DATA nmea_msg_t NMEA_LAST_MSG  = (nmea_msg_t) (NMEAMSG_END-1);
+    
+    //.......................................................................
+    //  Convert a nmea_msg_t to a PROGMEM string.
+    //    Useful for printing the sentence type instead of a number.
+    //    This can return NULL if the message is not a valid number.
+    
+    const __FlashStringHelper *string_for( nmea_msg_t msg ) const;
+
+    //.......................................................................
+    // Most recent NMEA sentence type received.
+
+    enum nmea_msg_t nmeaMessage NEOGPS_BF(8);
+
+    //.......................................................................
+    //  Storage for Talker and Manufacturer IDs, if configured
+
+    #ifdef NMEAGPS_SAVE_TALKER_ID
+      char talker_id[2];
+    #endif
+
+    #ifdef NMEAGPS_SAVE_MFR_ID
+      char mfr_id[3];
+    #endif
+
+    //.......................................................................
+    //  Current fix accessor.
+    //    /fix/ will be constantly changing as characters are received.
+    //
+    //  For example, fix().longitude() may return nonsense data if
+    //  characters for that field are currently being processed in /decode/.
+
+    gps_fix & fix() { return m_fix; };
+
+    //  NOTE: /is_safe/ *must* be checked before accessing members of /fix/.
+    //  If you need access to the current /fix/ at any time, you must
+    //  take a snapshot while it is_safe, and then use the snapshot
+    //  later.
+
+    //.......................................................................
+    //  Determine whether the members of /fix/ are "currently" safe.
+    //  It will return true when a complete sentence and the CRC characters 
+    //  have been received (or after a CR if no CRC is present).
+    //  It will return false after a sentence's command and comma
+    //  have been received (e.g., "$GPGGA,").
+
+    bool is_safe() const { return (rxState == NMEA_IDLE) || (fieldIndex == 0); }
+
+    //  Notes regarding is_safe() and fix():
+    //
+    //  If an NMEAGPS instance is fed characters inside a UART interrupt,
+    //    is_safe() could change at any time (i.e., it should be 
+    //    considered /volatile/).
+    //
+    //  If an NMEAGPS instance is fed characters from a non-interrupt
+    //    context, the following method is safe:
+    //
+    //  void loop()
+    //  {
+    //    while (uart.available()) {
+    //      if (gps.decode( uart.read() ) == DECODE_COMPLETED) {
+    //        // Got something new!  Access only valid members here and/or...
+    //
+    //        // ...save a snapshot for later
+    //        safe_fix = gps.fix();
+    //      }
+    //    }
+    //    // Access valid members of /safe_fix/ anywhere, any time.
+    //  }
+
+    //.......................................................................
+
+    #ifdef NMEAGPS_STATS
+      struct statistics_t {
+          uint32_t ok;         // count of successfully parsed sentences
+          uint32_t crc_errors; // count of CRC errors
+          uint32_t chars;
+          void init()
+            {
+              ok         = 0L;
+              crc_errors = 0L;
+              chars      = 0L;
+            }
+      } statistics;
+    #endif
+
+    //.......................................................................
+    // Request the specified NMEA sentence.  Not all devices will respond.
+
+    static void poll( Stream *device, nmea_msg_t msg );
+
+    //.......................................................................
+    // Send a message to the GPS device.
+    // The '$' is optional, and the '*' and CS will be added automatically.
+
+    static void send( Stream *device, const char *msg );
+    static void send_P( Stream *device, const __FlashStringHelper *msg );
+
+    //.......................................................................
+    // Indicate that the next sentence should initialize the internal fix()
+    //    This is useful for coherency or custom filtering.
+    
+    bool intervalComplete() const { return _intervalComplete; }
+    void intervalComplete( bool val ) { _intervalComplete = val; }
+
+    //.......................................................................
+    // Set all parsed data (fix(), satellite info, etc.) to initial values.
+
+    void data_init()
+    {
+      fix().init();
+
+      #ifdef NMEAGPS_PARSE_SATELLITES
+        sat_count = 0;
+      #endif
+    }
+
+    //.......................................................................
+    // Reset the parsing process.
+    //   This is used internally after a CS error, or could be used 
+    //   externally to abort processing if it has been too long 
+    //   since any data was received.
+
+    void reset()
+    {
+      rxState = NMEA_IDLE;
+    }
+
+    //.......................................................................
+    //  The OVERRUN flag is set whenever a fix is not read by the time
+    //  the next update interval starts.  You must clear it when you
+    //  detect the condition.
+
+    bool overrun() const { return _overrun; }
+    void overrun( bool val ) { _overrun = val; }
+
+protected:
+    //  Current fix
+    gps_fix m_fix;
+
+    // Current parser state
+    uint8_t      crc;            // accumulated CRC in the sentence
+    uint8_t      fieldIndex;     // index of current field in the sentence
+    uint8_t      chrCount;       // index of current character in current field
+    uint8_t      decimal;        // digits received after the decimal point
+    struct {
+      bool     negative          NEOGPS_BF(1); // field had a leading '-'
+      bool     _comma_needed     NEOGPS_BF(1); // field needs a comma to finish parsing
+      bool     group_valid       NEOGPS_BF(1); // multi-field group valid
+      bool     _overrun          NEOGPS_BF(1); // an entire fix was dropped
+      bool     _intervalComplete NEOGPS_BF(1); // automatically set after LAST received
+      #if (NMEAGPS_FIX_MAX == 0)
+        bool   _fixesAvailable   NEOGPS_BF(1);
+      #endif
+      #ifdef NMEAGPS_PARSE_PROPRIETARY
+        bool   proprietary       NEOGPS_BF(1); // receiving proprietary message
+      #endif
+    } NEOGPS_PACKED;
+
+    #ifdef NMEAGPS_PARSING_SCRATCHPAD
+      union {
+        uint32_t U4;
+        uint16_t U2[2];
+        uint8_t  U1[4];
+      } scratchpad;
+    #endif
+
+    bool comma_needed()
+    {
+      #ifdef NMEAGPS_COMMA_NEEDED
+        return _comma_needed;
+      #else
+        return false;
+      #endif
+    }
+
+    void comma_needed( bool value )
+    {
+      #ifdef NMEAGPS_COMMA_NEEDED
+        _comma_needed = value;
+      #endif
+    }
+
+    // Internal FSM states
+    enum rxState_t {
+        NMEA_IDLE,             // Waiting for initial '$'
+        NMEA_RECEIVING_HEADER, // Parsing sentence type field
+        NMEA_RECEIVING_DATA,   // Parsing fields up to the terminating '*'
+        NMEA_RECEIVING_CRC     // Receiving two-byte transmitted CRC
+    };
+    CONST_CLASS_DATA uint8_t NMEA_FIRST_STATE = NMEA_IDLE;
+    CONST_CLASS_DATA uint8_t NMEA_LAST_STATE  = NMEA_RECEIVING_CRC;
+
+    rxState_t rxState NEOGPS_BF(8);
+
+    //.......................................................................
+    //  Process one character, possibly saving a buffered fix
+
+    decode_t _handle( uint8_t c )
+    {
+      decode_t res = decode( c );
+
+      if (res == DECODE_COMPLETED) {
+
+        // Room for another fix?
+
+        if (((NMEAGPS_FIX_MAX == 0) &&  _available()) ||
+            ((NMEAGPS_FIX_MAX >  0) && (_available() >= NMEAGPS_FIX_MAX))) {
+
+          // NO ROOM!
+          overrun( true );
+
+        } else {
+
+          // YES, save it.
+          //   Note: If FIX_MAX == 0, this just marks _fixesAvailable = true.
+
+          #if (NMEAGPS_FIX_MAX > 0)
+            if (merging == EXPLICIT_MERGING) {
+              // Accumulate all sentences
+
+              #ifdef NMEAGPS_COHERENT
+                if (intervalComplete())
+                  buffer[ _currentFix ] = fix(); // start fresh
+                else
+              #endif
+                  buffer[ _currentFix ] |= fix();
+            }
+          #endif
+
+          intervalComplete( nmeaMessage == LAST_SENTENCE_IN_INTERVAL );
+          if ((merging == NO_MERGING) || intervalComplete()) {
+
+            #if (NMEAGPS_FIX_MAX > 0)
+
+              if (merging != EXPLICIT_MERGING)
+                buffer[ _currentFix ] = fix();
+
+              _currentFix++;
+              if (_currentFix >= NMEAGPS_FIX_MAX)
+                _currentFix = 0;
+
+              _fixesAvailable++;
+            #else
+              _fixesAvailable = true;
+            #endif
+          }
+        }
+
+      } else if ((NMEAGPS_FIX_MAX == 0) && _available() && !is_safe()) {
+        // No buffer, and m_fix is was modified by the last char
+        overrun( true );
+      }
+
+      return res;
+
+    } // _handle
+
+    //.......................................................................
+
+    uint8_t _available() const { return _fixesAvailable; };
+
+    //.......................................................................
+    //  Buffered fixes.
+
+    #if (NMEAGPS_FIX_MAX > 0)
+      gps_fix buffer[ NMEAGPS_FIX_MAX ]; // could be empty, see NMEAGPS_cfg.h
+      uint8_t _fixesAvailable;
+      uint8_t _firstFix;
+      uint8_t _currentFix;
+
+      //.......................................................................
+      //  Control access to the fix buffer.  This preserves atomicity when
+      //     the processing style is interrupt-driven.
+
+      void lock() const
+      {
+        if (processing_style == PS_INTERRUPT)
+          cli();
+      }
+
+      void unlock() const
+      {
+        if (processing_style == PS_INTERRUPT)
+          sei();
+      }
+    #endif
+
+    //.......................................................................
+    // Table entry for NMEA sentence type string and its offset
+    // in enumerated nmea_msg_t.  Proprietary sentences can be implemented
+    // in derived classes by adding a second table.  Additional tables
+    // can be singly-linked through the /previous/ member.  The instantiated
+    // class's table is the head, and should be returned by the derived
+    // /msg_table/ function.  Tables should be sorted alphabetically.
+
+    struct msg_table_t {
+      uint8_t             offset;  // nmea_msg_t enum starting value
+      const msg_table_t  *previous;
+      uint8_t             size;    // number of entries in table array
+      const char * const *table;   // array of NMEA sentence strings
+    };
+
+    static const msg_table_t  nmea_msg_table __PROGMEM;
+
+    NMEAGPS_VIRTUAL const msg_table_t *msg_table() const
+      { return &nmea_msg_table; };
+
+    //.......................................................................
+    //  These virtual methods can accept or reject 
+    //    the talker ID (for standard sentences) or 
+    //    the manufacturer ID (for proprietary sentences).
+    //  The default is to accept *all* IDs.
+    //  Override them if you want to reject certain IDs, or you want
+    //    to handle COMPLETED sentences from certain IDs differently.
+
+    #ifdef NMEAGPS_PARSE_TALKER_ID
+      NMEAGPS_VIRTUAL bool parseTalkerID( char ) { return true; };
+    #endif
+
+    #ifdef NMEAGPS_PARSE_PROPRIETARY
+      #ifdef NMEAGPS_PARSE_MFR_ID
+        NMEAGPS_VIRTUAL bool parseMfrID( char ) { return true; };
+      #endif
+    #endif
+
+    //.......................................................................
+    // Try to recognize an NMEA sentence type, after the IDs have been accepted.
+
+    decode_t parseCommand( char c );
+    decode_t parseCommand( const msg_table_t *msgs, uint8_t cmdCount, char c );
+
+    //.......................................................................
+    // Parse various NMEA sentences
+
+    bool parseGGA( char chr );
+    bool parseGLL( char chr );
+    bool parseGSA( char chr );
+    bool parseGST( char chr );
+    bool parseGSV( char chr );
+    bool parseRMC( char chr );
+    bool parseVTG( char chr );
+    bool parseZDA( char chr );
+
+    //.......................................................................
+    // Depending on the NMEA sentence type, parse one field of an expected type.
+
+    NMEAGPS_VIRTUAL bool parseField( char chr );
+
+    //.......................................................................
+    // Parse the primary NMEA field types into /fix/ members.
+
+    bool parseFix        ( char chr ); // aka STATUS or MODE
+    bool parseTime       ( char chr );
+    bool parseDDMMYY     ( char chr );
+    bool parseLat        ( char chr );
+    bool parseNS         ( char chr );
+    bool parseLon        ( char chr );
+    bool parseEW         ( char chr );
+    bool parseSpeed      ( char chr );
+    bool parseHeading    ( char chr );
+    bool parseAlt        ( char chr );
+    bool parseGeoidHeight( char chr );
+    bool parseHDOP       ( char chr );
+    bool parseVDOP       ( char chr );
+    bool parsePDOP       ( char chr );
+    bool parse_lat_err   ( char chr );
+    bool parse_lon_err   ( char chr );
+    bool parse_alt_err   ( char chr );
+    bool parseSatellites ( char chr );
+
+    // Helper macro for parsing the 4 consecutive fields of a location
+    #define PARSE_LOC(i) case i: return parseLat( chr );\
+      case i+1: return parseNS ( chr ); \
+      case i+2: return parseLon( chr ); \
+      case i+3: return parseEW ( chr );
+
+public:
+    // Optional SATELLITE VIEW array    -----------------------
+    #ifdef NMEAGPS_PARSE_SATELLITES
+      struct satellite_view_t
+      {
+        uint8_t    id;
+        #ifdef NMEAGPS_PARSE_SATELLITE_INFO
+          uint8_t  elevation; // 0..99 deg
+          uint16_t azimuth;   // 0..359 deg
+          uint8_t  snr     NEOGPS_BF(7); // 0..99 dBHz
+          bool     tracked NEOGPS_BF(1);
+        #endif
+      } NEOGPS_PACKED;
+
+      satellite_view_t satellites[ NMEAGPS_MAX_SATELLITES ];
+      uint8_t sat_count;
+
+      bool satellites_valid() const { return (sat_count >= m_fix.satellites); }
+    #endif
+
+protected:
+
+    //.......................................................................
+    // Parse floating-point numbers into a /whole_frac/
+    // @return true when the value is fully populated.
+
+    bool parseFloat( gps_fix::whole_frac & val, char chr, uint8_t max_decimal );
+
+    //.......................................................................
+    // Parse floating-point numbers into a uint16_t
+    // @return true when the value is fully populated.
+
+    bool parseFloat( uint16_t & val, char chr, uint8_t max_decimal );
+
+    //.......................................................................
+    // Parse NMEA lat/lon dddmm.mmmm degrees
+
+    bool parseDDDMM
+      (
+        #if defined( GPS_FIX_LOCATION )
+          int32_t & val,
+        #endif
+        #if defined( GPS_FIX_LOCATION_DMS )
+          DMS_t & dms,
+        #endif
+        char chr
+      );
+
+    //.......................................................................
+    // Parse integer into 8-bit int
+    // @return true when non-empty value
+
+    bool parseInt( uint8_t &val, uint8_t chr )
+    {
+      bool is_comma = (chr == ',');
+      if (chrCount == 0) {
+        if (is_comma)
+          return false; // empty field!
+        val = (chr - '0');
+      } else if (!is_comma)
+        val = (val*10) + (chr - '0');
+      return true;
+    }
+
+    //.......................................................................
+    // Parse integer into signed 8-bit int
+    // @return true when non-empty value
+
+    bool parseInt( int8_t &val, uint8_t chr )
+    {
+      bool is_comma = (chr == ',');
+
+      if (chrCount == 0) {
+        if (is_comma)
+          return false; // empty field!
+
+        if (chr == '-') {
+          negative = true;
+          comma_needed( true ); // to negate
+        } else if (chr == '+') {
+          ;
+        } else {
+          val = (chr - '0');
+        }
+      } else if (!is_comma) {
+        val = (val*10) + (chr - '0');
+
+      } else if (negative) {
+        val = -val;
+      }
+
+      return true;
+    }
+
+    //.......................................................................
+    // Parse integer into 16-bit int
+    // @return true when non-empty value
+
+    bool parseInt( uint16_t &val, uint8_t chr )
+    {
+      bool is_comma = (chr == ',');
+      if (chrCount == 0) {
+        if (is_comma)
+          return false; // empty field!
+        val = (chr - '0');
+      } else if (!is_comma)
+        val = (val*10) + (chr - '0');
+      return true;
+    }
+
+    //.......................................................................
+    // Parse integer into 32-bit int
+    // @return true when non-empty value
+
+    bool parseInt( uint32_t &val, uint8_t chr )
+    {
+      bool is_comma = (chr == ',');
+      if (chrCount == 0) {
+        if (is_comma)
+          return false; // empty field!
+        val = (chr - '0');
+      } else if (!is_comma)
+        val = (val*10) + (chr - '0');
+      return true;
+    }
+
+private:
+    void sentenceBegin       ();
+    void sentenceOk          ();
+    void sentenceInvalid     ();
+    void sentenceUnrecognized();
+    void headerReceived      ();
+
+} NEOGPS_PACKED;
+
+#endif

--- a/NMEAGPS_cfg.h
+++ b/NMEAGPS_cfg.h
@@ -1,0 +1,286 @@
+#ifndef NMEAGPS_CFG_H
+#define NMEAGPS_CFG_H
+
+//------------------------------------------------------
+// Enable/disable the parsing of specific sentences.
+//
+// Configuring out a sentence prevents it from being recognized; it
+// will be completely ignored.  (See also NMEAGPS_RECOGNIZE_ALL, below)
+//
+// FYI: Only RMC and ZDA contain date information.  Other
+// sentences contain time information.  Both date and time are 
+// required if you will be doing time_t-to-clock_t operations.
+
+//#define NMEAGPS_PARSE_GGA
+//#define NMEAGPS_PARSE_GLL
+//#define NMEAGPS_PARSE_GSA
+//#define NMEAGPS_PARSE_GSV
+//#define NMEAGPS_PARSE_GST
+#define NMEAGPS_PARSE_RMC
+//#define NMEAGPS_PARSE_VTG
+//#define NMEAGPS_PARSE_ZDA
+
+//------------------------------------------------------
+// Select which sentence is sent *last* by your GPS device
+// in each update interval.  This can be used by your sketch
+// to determine when the GPS quiet time begins, and thus
+// when you can perform "some" time-consuming operations.
+
+#define LAST_SENTENCE_IN_INTERVAL NMEAGPS::NMEA_RMC
+
+// If the NMEA_LAST_SENTENCE_IN_INTERVAL is not chosen 
+// correctly, GPS data may be lost because the sketch
+// takes too long elsewhere when this sentence is received.
+// Also, fix members may contain information from different 
+// time intervals (i.e., they are not coherent).
+//
+// If you don't know which sentence is the last one,
+// use NMEAorder.ino to list them.  You do not have to select
+// the last sentence the device sends if you have disabled
+// it.  Just select the last sentence that you have *enabled*.
+
+//------------------------------------------------------
+// Enable/Disable coherency:
+//
+// If you need each fix to contain information that is only
+// from the current update interval, you should uncomment
+// this define.  At the beginning of the next interval,
+// the accumulating fix will start out empty.  When
+// the LAST_SENTENCE_IN_INTERVAL arrives, the valid
+// fields will be coherent.
+
+//#define NMEAGPS_COHERENT
+
+// With IMPLICIT merging, fix() will be emptied when the
+// next sentence begins.
+//
+// With EXPLICIT or NO merging, the fix() was already
+// being initialized.
+//
+// If you use the fix-oriented methods available() and read(),
+// they will empty the current fix for you automatically.
+//
+// If you use the character-oriented method decode(), you should
+// empty the accumulating fix by testing and clearing the
+// 'intervalComplete' flag in the same way that available() does.
+
+//------------------------------------------------------
+// Choose how multiple sentences are merged:
+//   1) No merging
+//        Each sentence fills out its own fix; there could be 
+//        multiple sentences per interval.
+//   2) EXPLICIT_MERGING
+//        All sentences in an interval are *safely* merged into one fix.
+//        NMEAGPS_FIX_MAX must be >= 1.
+//        An interval is defined by NMEA_LAST_SENTENCE_IN_INTERVAL.
+//   3) IMPLICIT_MERGING
+//        All sentences in an interval are merged into one fix, with 
+//        possible data loss.  If a received sentence is rejected for 
+//        any reason (e.g., a checksum error), all the values are suspect.
+//        The fix will be cleared; no members will be valid until new 
+//        sentences are received and accepted.  This uses less RAM.
+//        An interval is defined by NMEA_LAST_SENTENCE_IN_INTERVAL.
+// Uncomment zero or one:
+
+//#define NMEAGPS_EXPLICIT_MERGING
+#define NMEAGPS_IMPLICIT_MERGING
+
+#ifdef NMEAGPS_IMPLICIT_MERGING
+  #define NMEAGPS_MERGING NMEAGPS::IMPLICIT_MERGING
+
+  // When accumulating, nothing is done to the fix at the 
+  // beginning of every sentence...
+  #ifdef NMEAGPS_COHERENT
+    // ...unless COHERENT is enabled and a new interval is starting
+    #define NMEAGPS_INIT_FIX(m) \
+      if (intervalComplete()) { intervalComplete( false ); m.valid.init(); }
+  #else
+    #define NMEAGPS_INIT_FIX(m)
+  #endif
+
+  // ...but we invalidate one part when it starts to get parsed.  It *may* get
+  // validated when the parsing is finished.
+  #define NMEAGPS_INVALIDATE(m) m_fix.valid.m = false
+
+#else
+
+  #ifdef NMEAGPS_EXPLICIT_MERGING
+    #define NMEAGPS_MERGING NMEAGPS::EXPLICIT_MERGING
+  #else
+    #define NMEAGPS_MERGING NMEAGPS::NO_MERGING
+    #define NMEAGPS_NO_MERGING
+  #endif
+
+  // When NOT accumulating, invalidate the entire fix at the 
+  // beginning of every sentence
+  #define NMEAGPS_INIT_FIX(m) m.valid.init()
+
+  // ...so the individual parts do not need to be invalidated as they are parsed
+  #define NMEAGPS_INVALIDATE(m)
+
+#endif
+
+#if ( defined(NMEAGPS_NO_MERGING) + \
+    defined(NMEAGPS_IMPLICIT_MERGING) + \
+    defined(NMEAGPS_EXPLICIT_MERGING) )  > 1
+  #error Only one MERGING technique should be enabled in NMEAGPS_cfg.h!
+#endif
+
+//------------------------------------------------------
+// Define the fix buffer size.  The NMEAGPS object will hold on to
+// this many fixes before an overrun occurs.  This can be zero,
+// but you have to be more careful about using gps.fix() structure,
+// because it will be modified as characters are received.
+
+#define NMEAGPS_FIX_MAX 0
+
+#if defined(NMEAGPS_EXPLICIT_MERGING) && (NMEAGPS_FIX_MAX == 0)
+  #error You must define FIX_MAX >= 1 to allow EXPLICIT merging in NMEAGPS_cfg.h
+#endif
+
+//------------------------------------------------------
+// Enable/Disable interrupt-style processing of GPS characters
+// If you are using one of the NeoXXSerial libraries,
+//   to attachInterrupt, this must be defined.
+// Otherwise, it must be commented out.
+
+//#define NMEAGPS_INTERRUPT_PROCESSING
+
+#ifdef  NMEAGPS_INTERRUPT_PROCESSING
+  #define NMEAGPS_PROCESSING_STYLE NMEAGPS::PS_INTERRUPT
+#else
+  #define NMEAGPS_PROCESSING_STYLE NMEAGPS::PS_POLLING
+#endif
+
+//------------------------------------------------------
+// Enable/disable the talker ID, manufacturer ID and proprietary message processing.
+//
+// First, some background information.  There are two kinds of NMEA sentences:
+//
+// 1. Standard NMEA sentences begin with "$ttccc", where
+//      "tt" is the talker ID, and
+//      "ccc" is the variable-length sentence type (i.e., command).
+//
+//    For example, "$GPGLL,..." is a GLL sentence (Geographic Lat/Long) 
+//    transmitted by talker "GP".  This is the most common talker ID.  Some
+//    devices may report "$GNGLL,..." when a mix of GPS and non-GPS
+//    satellites have been used to determine the GLL data.
+//
+// 2. Proprietary NMEA sentences (i.e., those unique to a particular
+//    manufacturer) begin with "$Pmmmccc", where
+//      "P" is the NMEA-defined prefix indicator for proprietary messages,
+//      "mmm" is the 3-character manufacturer ID, and
+//      "ccc" is the variable-length sentence type (it can be empty).
+//
+// No validation of manufacturer ID and talker ID is performed in this
+// base class.  For example, although "GP" is a common talker ID, it is not
+// guaranteed to be transmitted by your particular device, and it IS NOT
+// REQUIRED.  If you need validation of these IDs, or you need to use the
+// extra information provided by some devices, you have two independent
+// options:
+//
+// 1. Enable SAVING the ID: When /decode/ returns DECODE_COMPLETED, the
+// /talker_id/ and/or /mfr_id/ members will contain ID bytes.  The entire
+// sentence will be parsed, perhaps modifying members of /fix/.  You should
+// enable one or both IDs if you want the information in all sentences *and*
+// you also want to know the ID bytes.  This adds two bytes of RAM for the
+// talker ID, and 3 bytes of RAM for the manufacturer ID.
+//
+// 2. Enable PARSING the ID:  The virtual /parse_talker_id/ and
+// /parse_mfr_id/ will receive each ID character as it is parsed.  If it
+// is not a valid ID, return /false/ to abort processing the rest of the
+// sentence.  No CPU time will be wasted on the invalid sentence, and no
+// /fix/ members will be modified.  You should enable this if you want to
+// ignore some IDs.  You must override /parse_talker_id/ and/or
+// /parse_mfr_id/ in a derived class.
+//
+
+//#define NMEAGPS_SAVE_TALKER_ID
+//#define NMEAGPS_PARSE_TALKER_ID
+
+//#define NMEAGPS_PARSE_PROPRIETARY
+#ifdef NMEAGPS_PARSE_PROPRIETARY
+  //#define NMEAGPS_SAVE_MFR_ID
+  #define NMEAGPS_PARSE_MFR_ID
+#endif
+
+//------------------------------------------------------
+// Enable/disable tracking the current satellite array and,
+// optionally, all the info for each satellite.
+//
+
+//#define NMEAGPS_PARSE_SATELLITES
+//#define NMEAGPS_PARSE_SATELLITE_INFO
+
+#ifdef NMEAGPS_PARSE_SATELLITES
+  #define NMEAGPS_MAX_SATELLITES (20)
+
+  #ifndef GPS_FIX_SATELLITES
+    #error GPS_FIX_SATELLITES must be defined in GPSfix.h!
+  #endif
+
+#endif
+
+#if defined(NMEAGPS_PARSE_SATELLITE_INFO) & \
+    !defined(NMEAGPS_PARSE_SATELLITES)
+  #error NMEAGPS_PARSE_SATELLITES must be defined!
+#endif
+
+//------------------------------------------------------
+// Enable/disable gathering interface statistics:
+// CRC errors and number of sentences received
+
+//#define NMEAGPS_STATS
+
+//------------------------------------------------------
+// Configuration item for allowing derived types of NMEAGPS.
+// If you derive classes from NMEAGPS, you *must* define NMEAGPS_DERIVED_TYPES.
+// If not defined, virtuals are not used, with a slight size (2 bytes) and 
+// execution time savings.
+
+//#define NMEAGPS_DERIVED_TYPES
+
+#ifdef NMEAGPS_DERIVED_TYPES
+  #define NMEAGPS_VIRTUAL virtual
+#else
+  #define NMEAGPS_VIRTUAL
+#endif
+
+//-----------------------------------
+// See if DERIVED_TYPES is required
+#if (defined(NMEAGPS_PARSE_TALKER_ID) | defined(NMEAGPS_PARSE_MFR_ID)) &  \
+           !defined(NMEAGPS_DERIVED_TYPES)
+  #error You must define NMEAGPS_DERIVED_TYPES in NMEAGPS.h in order to parse Talker and/or Mfr IDs!
+#endif
+
+//------------------------------------------------------
+// Some devices may omit trailing commas at the end of some 
+// sentences.  This may prevent the last field from being 
+// parsed correctly, because the parser for some types keep 
+// the value in an intermediate state until the complete 
+// field is received (e.g., parseDDDMM, parseFloat and 
+// parseZDA).
+//
+// Enabling this will inject a simulated comma when the end 
+// of a sentence is received and the last field parser 
+// indicated that it still needs one.
+
+//#define NMEAGPS_COMMA_NEEDED
+
+//------------------------------------------------------
+//  Some applications may want to recognize a sentence type
+//  without actually parsing any of the fields.  Uncommenting
+//  this define will allow the nmeaMessage member to be set
+//  when *any* standard message is seen, even though that 
+//  message is not enabled by a NMEAGPS_PARSE_xxx define above.
+//  No valid flags will be true for those sentences.
+
+//#define NMEAGPS_RECOGNIZE_ALL
+
+//------------------------------------------------------
+// Sometimes, a little extra space is needed to parse an intermediate form.
+// This config items enables extra space.
+
+//#define NMEAGPS_PARSING_SCRATCHPAD
+
+#endif

--- a/NeoGPS_cfg.h
+++ b/NeoGPS_cfg.h
@@ -1,0 +1,83 @@
+#ifndef NEOGPS_CFG
+#define NEOGPS_CFG
+
+/**
+ * Enable/disable packed data structures.
+ *
+ * Enabling packed data structures will use two less-portable language
+ * features of GCC to reduce RAM requirements.  Although it was expected to slightly increase execution time and code size, the reverse is true on 8-bit AVRs: the code is smaller and faster with packing enabled.
+ *
+ * Disabling packed data structures will be very portable to other
+ * platforms.  NeoGPS configurations will use slightly more RAM, and on
+ * 8-bit AVRs, the speed is slightly slower, and the code is slightly
+ * larger.  There may be no choice but to disable packing on processors 
+ * that do not support packed structures.
+ *
+ * There may also be compiler-specific switches that affect packing and the
+ * code which accesses packed members.  YMMV.
+ **/
+
+#define NEOGPS_PACKED_DATA
+
+//------------------------------------------------------------------------
+// Based on the above define, choose which set of packing macros should
+// be used in the rest of the NeoGPS package.  Do not change these defines.
+
+#ifdef NEOGPS_PACKED_DATA
+
+  // This is for specifying the number of bits to be used for a 
+  // member of a struct.  Booleans are typically one bit.
+  #define NEOGPS_BF(b) :b
+
+  // This is for requesting the compiler to pack the struct or class members
+  // "as closely as possible".  This is a compiler-dependent interpretation.
+  #define NEOGPS_PACKED __attribute__((packed))
+
+#else
+
+  // Let the compiler do whatever it wants.
+
+  #define NEOGPS_PACKED
+  #define NEOGPS_BF(b)
+
+#endif
+
+/*
+ *  Accommodate C++ compiler and IDE changes.
+ *
+ *  Declaring constants as class data instead of instance data helps avoid
+ *  collisions with #define names, and allows the compiler to perform more
+ *  checks on their usage.
+ *
+ *  Until C++ 10 and IDE 1.6.8, initialized class data constants 
+ *  were declared like this:
+ *
+ *      static const <valued types> = <constant-value>;
+ *
+ *  Now, non-simple types (e.g., float) must be declared as
+ *
+ *      static constexpr <nonsimple-types> = <expression-treated-as-const>;
+ *
+ *  The good news is that this allows the compiler to optimize out an
+ *  expression that is "promised" to be "evaluatable" as a constant.
+ *  The bad news is that it introduces a new language keyword, and the old
+ *  code raises an error.
+ *
+ *  TODO: Evaluate the requirement for the "static" keyword.
+ *  TODO: Evaluate using a C++ version preprocessor symbol for the #if.
+ *
+ *  The CONST_CLASS_DATA define will expand to the appropriate keywords.
+ *
+ */
+
+#if ARDUINO < 10606
+
+  #define CONST_CLASS_DATA static const
+  
+#else
+
+  #define CONST_CLASS_DATA static constexpr
+  
+#endif
+
+#endif

--- a/README.md
+++ b/README.md
@@ -1,37 +1,8 @@
-# AnalogGPSChrono
+# AnalogGPSChrono fork
 
-This is a piece of Arduino/ATTiny85 code for pulling the GPS speed of a standard serial and displaying it on a tachometer that is placed in a chronometer.
+This is a forked version that uses the [NeoGPS](https://github.com/SlashDevin/NeoGPS) library to obtain the speed from the GPRMC sentence:
 
-# Basics
-
-Demo and description given on [youtube](https://www.youtube.com/watch?v=pP-rwahyP9g)
-
-Essentially the ublox6 gives the ATtiny85 the GPS speed which the ATTiny85 translates to a square wave which the tachometer needs.
-
-* Tacho that I used is this one: [DX](http://www.dx.com/p/iztoss-b714-universal-motorcycle-modified-retro-led-backlight-tachometer-speedometer-tacho-gauge-420110#.V12kf0p97_h)- Has to run off 12V with a square wave signal centered around 0 and at least a 4V peak to peak swing.
-* GPS Chip: [DX](http://www.dx.com/p/gps-module-w-ceramic-passive-antenna-for-raspberry-pi-arduino-red-384916#.V12knEp97_h)- Runs perfectly off the ATTiny85
-
-# Basic Code Stuff
-
-The code uses the following 3 libraries:
-
-1. [TinyGPS++](http://arduiniana.org/libraries/tinygpsplus/)
-2. [TrinketTone](http://w8bh.net/avr/TrinketTone.pdf)- Note that this was modified to be used in the program
-3. [ATTinyCore](https://github.com/SpenceKonde/ATTinyCore)
-
-
-The ATTiny85 had to use a crystal (16MHz) to keep the timing for the serial accurate. One pin goes to the signal line (via a capacitor and resistor- to get signal centered around 0) of the tachometer. The other pin is the RX from the GPS.
-
-Also note that it is possible to program your ATTiny85 using your Arduino as the ISP- shown [here](http://highlowtech.org/?p=1695)
-
-# TODO
-
-There are a number of little odds and ends I would still like to do.
-
-1. Possible filter over the output, just to smooth it a little, however this will cause a larger delay.
-2. Make the speedo show the number of satellites it has found until it has a lock.
-3. Cooler startup sequence.
-
-# Finally
-
-Any comments and contributions are most welcome.
+* Program size is only 3800 bytes (3180 bytes smaller!)
+* It only uses 137 bytes of RAM (214 bytes saved!)
+* Added low-pass filter to gpsFunctions
+* NeoGPS configuration files are set to parse RMC and speed field *ONLY* (much faster).  Also configured for IMPLICIT merging and no extra fix structures.

--- a/generateWave.ino
+++ b/generateWave.ino
@@ -1,10 +1,12 @@
-void squareWave(uint16_t frequency)
+void squareWave( uint16_t frequency )
 {
-  uint32_t ocr = F_CPU / frequency / 2;
-  uint8_t prescalarBits = 1;
-  if (frequency == 0)TCCR1 = 0x90; // stop the counter
+  if (frequency == 0)
+    TCCR1 = 0x90; // stop the counter
   else
   {
+    uint32_t ocr           = F_CPU / frequency / 2;
+    uint8_t  prescalarBits = 1;
+
     while (ocr > 255)
     {
       prescalarBits++;

--- a/gpsFunctions.ino
+++ b/gpsFunctions.ino
@@ -1,40 +1,24 @@
-void speedProcess(float currentSpeed, bool valid)
+static const uint16_t MIN_KNOTS =  10; // ~11 mph
+static const uint16_t MAX_KNOTS =  35; // ~40 mph
+static const uint16_t MIN_HZ    =  14;
+static const uint16_t MAX_HZ    = 200;
+
+void speedProcess( uint16_t knots )
 {
-  if (!valid) 
-  {
-    squareWave(100);
-  }
-  else
-  {
-    if (round(currentSpeed) != round(lastSpeed))
-    {
-      lastSpeed = currentSpeed;
-      speedHz(currentSpeed);
-      smartDelay(0);
-    }
-  }
+  if (knots < MIN_KNOTS)
+    knots = MIN_KNOTS;
+  else if (knots > MAX_KNOTS)
+    knots = MAX_KNOTS;
+
+  // Simple Low-Pass filter with a window of 4 samples
+  static uint16_t averageKnots = 0;
+  averageKnots = (averageKnots * 3) / 4  + knots;
+  knots = averageKnots / 4;
+
+  // Map the 10-35 knots onto 14-200 Hz
+  uint16_t iHz =
+    ((knots - MIN_KNOTS) * (MAX_HZ-MIN_HZ)) / (MAX_KNOTS-MIN_KNOTS) + MIN_HZ;
+
+  squareWave(iHz);
 }
-
-void smartDelay(unsigned long ms)
-{
-  unsigned long start = millis();
-  do
-  {
-    while (ss.available())
-      gps.encode(ss.read());
-  } while (millis() - start < ms);
-}
-
-
-void speedHz (float speedMPH)
-{
-  float iHz;
-  if (speedMPH < 11) iHz = 0;
-  else if (speedMPH > 40) iHz = 200;
-  else iHz = map(speedMPH, 11, 40, 14, 200);
-  squareWave(int(round(iHz)));
-//  squareWave(speedMPH);
-}
-
-
 


### PR DESCRIPTION
I wrote [NeoGPS](https://github.com/SlashDevin/NeoGPS) especially for these "tight" environments and thought you might be interested in seeing how it much it helps.  If you are going to add more features, this will give you quite a bit more room.  The program size is 3800 bytes (vs. 6982 original), and only uses 137 bytes of RAM (vs. 351 original), a significant savings.

I also added the low-pass filter you mentioned.  To add the satellites, you should
- enable `GPS_FIX_SATELLITES` in **GPSfix_cfg.h** (uncomment the `#define`),
- enable `NMEAGPS_PARSE_GGA` in **NMEAGPS_cfg.h**, and 
- use the `fix.satellites` value in `loop()`.

You may also need to change `LAST_SENTENCE_IN_INTERVAL` to `NMEAGPS::NMEA_GGA`, also  in **NMEAGPS_cfg.h**.  You can use the diagnostic program NMEAorder.ino to confirm that for your GPS device.

Cheers!
